### PR TITLE
Implement planner and shopping list features

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -33,17 +33,27 @@ namespace FoodbookApp
 
             // 🔧 Rejestracja serwisów i VM
             builder.Services.AddScoped<IRecipeService, RecipeService>();
+            builder.Services.AddScoped<IPlannerService, PlannerService>();
+            builder.Services.AddScoped<IShoppingListService, ShoppingListService>();
+
             builder.Services.AddScoped<RecipeViewModel>();
             builder.Services.AddScoped<AddRecipeViewModel>();
+            builder.Services.AddScoped<PlannerViewModel>();
+            builder.Services.AddScoped<ShoppingListViewModel>();
+
             builder.Services.AddHttpClient<RecipeImporter>();
 
             // 🧭 Rejestracja widoków (Pages), jeśli używasz DI do ich tworzenia
             builder.Services.AddScoped<RecipesPage>();
             builder.Services.AddScoped<AddRecipePage>();
+            builder.Services.AddScoped<PlannerPage>();
+            builder.Services.AddScoped<ShoppingListPage>();
 
             // 🧠 Rejestracja routów do Shell (opcjonalne, jeśli używasz Shell)
             Routing.RegisterRoute(nameof(RecipesPage), typeof(RecipesPage));
             Routing.RegisterRoute(nameof(AddRecipePage), typeof(AddRecipePage));
+            Routing.RegisterRoute(nameof(PlannerPage), typeof(PlannerPage));
+            Routing.RegisterRoute(nameof(ShoppingListPage), typeof(ShoppingListPage));
 
             // ✨ Build aplikacji
             var app = builder.Build();

--- a/Services/IShoppingListService.cs
+++ b/Services/IShoppingListService.cs
@@ -1,0 +1,9 @@
+using Foodbook.Models;
+
+namespace Foodbook.Services
+{
+    public interface IShoppingListService
+    {
+        Task<List<Ingredient>> GetShoppingListAsync(DateTime from, DateTime to);
+    }
+}

--- a/Services/ShoppingListService.cs
+++ b/Services/ShoppingListService.cs
@@ -1,0 +1,39 @@
+using Foodbook.Data;
+using Foodbook.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Foodbook.Services;
+
+public class ShoppingListService : IShoppingListService
+{
+    private readonly AppDbContext _context;
+
+    public ShoppingListService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<Ingredient>> GetShoppingListAsync(DateTime from, DateTime to)
+    {
+        var meals = await _context.PlannedMeals
+            .Include(pm => pm.Recipe)
+                .ThenInclude(r => r.Ingredients)
+            .Where(pm => pm.Date >= from && pm.Date <= to)
+            .ToListAsync();
+
+        var ingredients = meals
+            .SelectMany(pm => pm.Recipe?.Ingredients ?? Enumerable.Empty<Ingredient>());
+
+        var grouped = ingredients
+            .GroupBy(i => new { i.Name, i.Unit })
+            .Select(g => new Ingredient
+            {
+                Name = g.Key.Name,
+                Unit = g.Key.Unit,
+                Quantity = g.Sum(i => i.Quantity)
+            })
+            .ToList();
+
+        return grouped;
+    }
+}

--- a/ViewModels/PlannerViewModel.cs
+++ b/ViewModels/PlannerViewModel.cs
@@ -1,18 +1,51 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Foodbook.Models;
+using Foodbook.Services;
 
 namespace Foodbook.ViewModels
 {
     public class PlannerViewModel
     {
-        public ObservableCollection<PlannedMeal> PlannedMeals { get; set; } = new();
+        private readonly IPlannerService _plannerService;
+
+        public ObservableCollection<PlannedMeal> PlannedMeals { get; } = new();
+
         public ICommand AddMealCommand { get; }
         public ICommand RemoveMealCommand { get; }
 
-        public PlannerViewModel()
+        public PlannerViewModel(IPlannerService plannerService)
         {
-            // Stub: initialize commands
+            _plannerService = plannerService ?? throw new ArgumentNullException(nameof(plannerService));
+
+            AddMealCommand = new Command<PlannedMeal>(async meal => await AddMealAsync(meal));
+            RemoveMealCommand = new Command<PlannedMeal>(async meal => await RemoveMealAsync(meal));
+        }
+
+        public async Task LoadMealsAsync(DateTime from, DateTime to)
+        {
+            PlannedMeals.Clear();
+            var meals = await _plannerService.GetPlannedMealsAsync(from, to);
+            foreach (var meal in meals)
+                PlannedMeals.Add(meal);
+        }
+
+        private async Task AddMealAsync(PlannedMeal meal)
+        {
+            if (meal == null)
+                return;
+
+            await _plannerService.AddPlannedMealAsync(meal);
+            PlannedMeals.Add(meal);
+        }
+
+        private async Task RemoveMealAsync(PlannedMeal meal)
+        {
+            if (meal == null)
+                return;
+
+            await _plannerService.RemovePlannedMealAsync(meal.Id);
+            PlannedMeals.Remove(meal);
         }
     }
 }

--- a/ViewModels/ShoppingListViewModel.cs
+++ b/ViewModels/ShoppingListViewModel.cs
@@ -1,17 +1,30 @@
 using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Foodbook.Models;
+using Foodbook.Services;
 
 namespace Foodbook.ViewModels
 {
     public class ShoppingListViewModel
     {
-        public ObservableCollection<Ingredient> ShoppingList { get; set; } = new();
+        private readonly IShoppingListService _shoppingListService;
+
+        public ObservableCollection<Ingredient> ShoppingList { get; } = new();
         public ICommand GenerateListCommand { get; }
 
-        public ShoppingListViewModel()
+        public ShoppingListViewModel(IShoppingListService shoppingListService)
         {
-            // Stub: initialize commands
+            _shoppingListService = shoppingListService ?? throw new ArgumentNullException(nameof(shoppingListService));
+
+            GenerateListCommand = new Command(async () => await GenerateListAsync());
+        }
+
+        public async Task GenerateListAsync()
+        {
+            var items = await _shoppingListService.GetShoppingListAsync(DateTime.Today, DateTime.Today.AddDays(7));
+            ShoppingList.Clear();
+            foreach (var item in items)
+                ShoppingList.Add(item);
         }
     }
 }

--- a/Views/PlannerPage.xaml.cs
+++ b/Views/PlannerPage.xaml.cs
@@ -1,12 +1,17 @@
 using Microsoft.Maui.Controls;
+using Foodbook.ViewModels;
 
 namespace Foodbook.Views
 {
     public partial class PlannerPage : ContentPage
     {
-        public PlannerPage()
+        private readonly PlannerViewModel _viewModel;
+
+        public PlannerPage(PlannerViewModel viewModel)
         {
             InitializeComponent();
+            _viewModel = viewModel;
+            BindingContext = _viewModel;
         }
     }
 }

--- a/Views/ShoppingListPage.xaml.cs
+++ b/Views/ShoppingListPage.xaml.cs
@@ -1,12 +1,17 @@
 using Microsoft.Maui.Controls;
+using Foodbook.ViewModels;
 
 namespace Foodbook.Views
 {
     public partial class ShoppingListPage : ContentPage
     {
-        public ShoppingListPage()
+        private readonly ShoppingListViewModel _viewModel;
+
+        public ShoppingListPage(ShoppingListViewModel viewModel)
         {
             InitializeComponent();
+            _viewModel = viewModel;
+            BindingContext = _viewModel;
         }
     }
 }


### PR DESCRIPTION
## Summary
- add services for planner and shopping list logic
- implement add/remove planner logic and aggregation of ingredients
- register new services, view models and pages in MauiProgram
- connect PlannerViewModel and ShoppingListViewModel to views

## Testing
- `dotnet build -v:m` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c4988fd38833088e3e19f6d3f19f3