### PR TITLE
Seed database at startup

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -4,6 +4,7 @@ using Foodbook.Data;
 using Foodbook.Services;
 using Foodbook.ViewModels;
 using Foodbook.Views; // Dodaj to, jeśli rejestrujesz Pages
+using System.Threading.Tasks;
 
 namespace FoodbookApp
 {
@@ -63,7 +64,7 @@ namespace FoodbookApp
             {
                 var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
                 db.Database.EnsureCreated();
-                // Możesz też dodać SeedData.InitializeAsync(db).Wait();
+                Task.Run(async () => await SeedData.InitializeAsync(db)).Wait();
             }
 
             return app;


### PR DESCRIPTION
## Summary
- import `System.Threading.Tasks` for `Task` usage
- seed initial data when creating the database

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685c64126efc83309d27c2ddfb8e7f79