### PR TITLE
Add CRUD views for recipes, ingredients and planner

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -14,6 +14,9 @@
             Title="Recipes"
             ContentTemplate="{DataTemplate views:RecipesPage}" />
         <ShellContent
+            Title="Ingredients"
+            ContentTemplate="{DataTemplate views:IngredientsPage}" />
+        <ShellContent
             Title="Planner"
             ContentTemplate="{DataTemplate views:PlannerPage}" />
         <ShellContent
@@ -21,8 +24,13 @@
             ContentTemplate="{DataTemplate views:ShoppingListPage}" />
     </TabBar>
 
-    <!-- Rejestracja trasy do AddRecipePage -->
     <ShellContent
         Route="AddRecipePage"
         ContentTemplate="{DataTemplate views:AddRecipePage}" />
+    <ShellContent
+        Route="IngredientFormPage"
+        ContentTemplate="{DataTemplate views:IngredientFormPage}" />
+    <ShellContent
+        Route="MealFormPage"
+        ContentTemplate="{DataTemplate views:MealFormPage}" />
 </Shell>

--- a/FoodbookApp.csproj
+++ b/FoodbookApp.csproj
@@ -74,15 +74,24 @@
 	  <MauiXaml Update="Views\HomePage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\PlannerPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\RecipesPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	  <MauiXaml Update="Views\ShoppingListPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
+          <MauiXaml Update="Views\PlannerPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\RecipesPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\IngredientsPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\IngredientFormPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\MealFormPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\ShoppingListPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
 	</ItemGroup>
 
 </Project>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -36,24 +36,34 @@ namespace FoodbookApp
             builder.Services.AddScoped<IRecipeService, RecipeService>();
             builder.Services.AddScoped<IPlannerService, PlannerService>();
             builder.Services.AddScoped<IShoppingListService, ShoppingListService>();
+            builder.Services.AddScoped<IIngredientService, IngredientService>();
 
             builder.Services.AddScoped<RecipeViewModel>();
             builder.Services.AddScoped<AddRecipeViewModel>();
             builder.Services.AddScoped<PlannerViewModel>();
             builder.Services.AddScoped<ShoppingListViewModel>();
+            builder.Services.AddScoped<IngredientsViewModel>();
+            builder.Services.AddScoped<IngredientFormViewModel>();
+            builder.Services.AddScoped<PlannedMealFormViewModel>();
 
             builder.Services.AddHttpClient<RecipeImporter>();
 
             // 🧭 Rejestracja widoków (Pages), jeśli używasz DI do ich tworzenia
             builder.Services.AddScoped<RecipesPage>();
             builder.Services.AddScoped<AddRecipePage>();
+            builder.Services.AddScoped<IngredientsPage>();
+            builder.Services.AddScoped<IngredientFormPage>();
             builder.Services.AddScoped<PlannerPage>();
+            builder.Services.AddScoped<MealFormPage>();
             builder.Services.AddScoped<ShoppingListPage>();
 
             // 🧠 Rejestracja routów do Shell (opcjonalne, jeśli używasz Shell)
             Routing.RegisterRoute(nameof(RecipesPage), typeof(RecipesPage));
             Routing.RegisterRoute(nameof(AddRecipePage), typeof(AddRecipePage));
+            Routing.RegisterRoute(nameof(IngredientFormPage), typeof(IngredientFormPage));
+            Routing.RegisterRoute(nameof(IngredientsPage), typeof(IngredientsPage));
             Routing.RegisterRoute(nameof(PlannerPage), typeof(PlannerPage));
+            Routing.RegisterRoute(nameof(MealFormPage), typeof(MealFormPage));
             Routing.RegisterRoute(nameof(ShoppingListPage), typeof(ShoppingListPage));
 
             // ✨ Build aplikacji

--- a/Services/IIngredientService.cs
+++ b/Services/IIngredientService.cs
@@ -1,0 +1,10 @@
+using Foodbook.Models;
+namespace Foodbook.Services;
+public interface IIngredientService
+{
+    Task<List<Ingredient>> GetIngredientsAsync();
+    Task<Ingredient?> GetIngredientAsync(int id);
+    Task AddIngredientAsync(Ingredient ingredient);
+    Task UpdateIngredientAsync(Ingredient ingredient);
+    Task DeleteIngredientAsync(int id);
+}

--- a/Services/IPlannerService.cs
+++ b/Services/IPlannerService.cs
@@ -8,7 +8,9 @@ namespace Foodbook.Services
     public interface IPlannerService
     {
         Task<List<PlannedMeal>> GetPlannedMealsAsync(DateTime from, DateTime to);
+        Task<PlannedMeal?> GetPlannedMealAsync(int id);
         Task AddPlannedMealAsync(PlannedMeal meal);
+        Task UpdatePlannedMealAsync(PlannedMeal meal);
         Task RemovePlannedMealAsync(int id);
     }
 }

--- a/Services/IngredientService.cs
+++ b/Services/IngredientService.cs
@@ -1,0 +1,40 @@
+using Foodbook.Data;
+using Foodbook.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace Foodbook.Services;
+
+public class IngredientService : IIngredientService
+{
+    private readonly AppDbContext _context;
+    public IngredientService(AppDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<Ingredient>> GetIngredientsAsync() => await _context.Ingredients.Where(i => i.RecipeId == 0).ToListAsync();
+
+    public async Task<Ingredient?> GetIngredientAsync(int id) => await _context.Ingredients.FindAsync(id);
+
+    public async Task AddIngredientAsync(Ingredient ingredient)
+    {
+        _context.Ingredients.Add(ingredient);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task UpdateIngredientAsync(Ingredient ingredient)
+    {
+        _context.Ingredients.Update(ingredient);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteIngredientAsync(int id)
+    {
+        var ing = await _context.Ingredients.FindAsync(id);
+        if (ing != null)
+        {
+            _context.Ingredients.Remove(ing);
+            await _context.SaveChangesAsync();
+        }
+    }
+}

--- a/Services/PlannerService.cs
+++ b/Services/PlannerService.cs
@@ -21,9 +21,20 @@ namespace Foodbook.Services
                 .ToListAsync();
         }
 
+        public async Task<PlannedMeal?> GetPlannedMealAsync(int id)
+        {
+            return await _context.PlannedMeals.Include(pm => pm.Recipe).FirstOrDefaultAsync(pm => pm.Id == id);
+        }
+
         public async Task AddPlannedMealAsync(PlannedMeal meal)
         {
             _context.PlannedMeals.Add(meal);
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task UpdatePlannedMealAsync(PlannedMeal meal)
+        {
+            _context.PlannedMeals.Update(meal);
             await _context.SaveChangesAsync();
         }
 

--- a/ViewModels/IngredientFormViewModel.cs
+++ b/ViewModels/IngredientFormViewModel.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Foodbook.Models;
+using Foodbook.Services;
+using Microsoft.Maui.Controls;
+
+namespace Foodbook.ViewModels;
+
+public class IngredientFormViewModel : INotifyPropertyChanged
+{
+    private readonly IIngredientService _service;
+    private Ingredient? _ingredient;
+
+    public string Name { get => _name; set { _name = value; OnPropertyChanged(); } }
+    private string _name = string.Empty;
+
+    public string Quantity { get => _quantity; set { _quantity = value; OnPropertyChanged(); } }
+    private string _quantity = string.Empty;
+
+    public Unit SelectedUnit { get => _unit; set { _unit = value; OnPropertyChanged(); } }
+    private Unit _unit;
+
+    public IEnumerable<Unit> Units { get; } = Enum.GetValues(typeof(Unit)).Cast<Unit>();
+
+    public ICommand SaveCommand { get; }
+
+    public IngredientFormViewModel(IIngredientService service)
+    {
+        _service = service;
+        SaveCommand = new Command(async () => await SaveAsync());
+    }
+
+    public async Task LoadAsync(int id)
+    {
+        var ing = await _service.GetIngredientAsync(id);
+        if (ing != null)
+        {
+            _ingredient = ing;
+            Name = ing.Name;
+            Quantity = ing.Quantity.ToString();
+            SelectedUnit = ing.Unit;
+        }
+    }
+
+    private async Task SaveAsync()
+    {
+        var qty = double.TryParse(Quantity, out var q) ? q : 0;
+        if (_ingredient == null)
+        {
+            var newIng = new Ingredient { Name = Name, Quantity = qty, Unit = SelectedUnit };
+            await _service.AddIngredientAsync(newIng);
+        }
+        else
+        {
+            _ingredient.Name = Name;
+            _ingredient.Quantity = qty;
+            _ingredient.Unit = SelectedUnit;
+            await _service.UpdateIngredientAsync(_ingredient);
+        }
+        await Shell.Current.GoToAsync("..");
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    void OnPropertyChanged([CallerMemberName] string name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/ViewModels/IngredientsViewModel.cs
+++ b/ViewModels/IngredientsViewModel.cs
@@ -1,0 +1,51 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Foodbook.Models;
+using Foodbook.Services;
+using Microsoft.Maui.Controls;
+
+namespace Foodbook.ViewModels;
+
+public class IngredientsViewModel : INotifyPropertyChanged
+{
+    private readonly IIngredientService _service;
+
+    public ObservableCollection<Ingredient> Ingredients { get; } = new();
+
+    public ICommand AddCommand { get; }
+    public ICommand EditCommand { get; }
+    public ICommand DeleteCommand { get; }
+
+    public IngredientsViewModel(IIngredientService service)
+    {
+        _service = service;
+        AddCommand = new Command(async () => await Shell.Current.GoToAsync(nameof(IngredientFormPage)));
+        EditCommand = new Command<Ingredient>(async ing =>
+        {
+            if (ing != null)
+                await Shell.Current.GoToAsync($"{nameof(IngredientFormPage)}?id={ing.Id}");
+        });
+        DeleteCommand = new Command<Ingredient>(async ing => await DeleteIngredientAsync(ing));
+    }
+
+    public async Task LoadAsync()
+    {
+        Ingredients.Clear();
+        var list = await _service.GetIngredientsAsync();
+        foreach (var i in list)
+            Ingredients.Add(i);
+    }
+
+    private async Task DeleteIngredientAsync(Ingredient? ing)
+    {
+        if (ing == null) return;
+        await _service.DeleteIngredientAsync(ing.Id);
+        Ingredients.Remove(ing);
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    void OnPropertyChanged([CallerMemberName] string name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/ViewModels/PlannedMealFormViewModel.cs
+++ b/ViewModels/PlannedMealFormViewModel.cs
@@ -1,0 +1,74 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Windows.Input;
+using Foodbook.Models;
+using Foodbook.Services;
+using Microsoft.Maui.Controls;
+
+namespace Foodbook.ViewModels;
+
+public class PlannedMealFormViewModel : INotifyPropertyChanged
+{
+    private readonly IPlannerService _plannerService;
+    private readonly IRecipeService _recipeService;
+    private PlannedMeal? _meal;
+
+    public ObservableCollection<Recipe> Recipes { get; } = new();
+
+    public Recipe? SelectedRecipe { get => _selectedRecipe; set { _selectedRecipe = value; OnPropertyChanged(); } }
+    private Recipe? _selectedRecipe;
+
+    public DateTime Date { get => _date; set { _date = value; OnPropertyChanged(); } }
+    private DateTime _date = DateTime.Today;
+
+    public ICommand SaveCommand { get; }
+
+    public PlannedMealFormViewModel(IPlannerService plannerService, IRecipeService recipeService)
+    {
+        _plannerService = plannerService;
+        _recipeService = recipeService;
+        SaveCommand = new Command(async () => await SaveAsync());
+    }
+
+    public async Task LoadAsync(int id)
+    {
+        await LoadRecipesAsync();
+        var meal = await _plannerService.GetPlannedMealAsync(id);
+        if (meal != null)
+        {
+            _meal = meal;
+            Date = meal.Date;
+            SelectedRecipe = Recipes.FirstOrDefault(r => r.Id == meal.RecipeId);
+        }
+    }
+
+    public async Task LoadRecipesAsync()
+    {
+        Recipes.Clear();
+        var rec = await _recipeService.GetRecipesAsync();
+        foreach (var r in rec)
+            Recipes.Add(r);
+    }
+
+    private async Task SaveAsync()
+    {
+        if (SelectedRecipe == null) return;
+        if (_meal == null)
+        {
+            var m = new PlannedMeal { RecipeId = SelectedRecipe.Id, Date = Date };
+            await _plannerService.AddPlannedMealAsync(m);
+        }
+        else
+        {
+            _meal.RecipeId = SelectedRecipe.Id;
+            _meal.Date = Date;
+            await _plannerService.UpdatePlannedMealAsync(_meal);
+        }
+        await Shell.Current.GoToAsync("..");
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    void OnPropertyChanged([CallerMemberName] string name = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}

--- a/ViewModels/PlannerViewModel.cs
+++ b/ViewModels/PlannerViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Windows.Input;
 using Foodbook.Models;
 using Foodbook.Services;
+using Microsoft.Maui.Controls;
 
 namespace Foodbook.ViewModels
 {
@@ -12,14 +13,20 @@ namespace Foodbook.ViewModels
         public ObservableCollection<PlannedMeal> PlannedMeals { get; } = new();
 
         public ICommand AddMealCommand { get; }
-        public ICommand RemoveMealCommand { get; }
+        public ICommand EditMealCommand { get; }
+        public ICommand DeleteMealCommand { get; }
 
         public PlannerViewModel(IPlannerService plannerService)
         {
             _plannerService = plannerService ?? throw new ArgumentNullException(nameof(plannerService));
 
-            AddMealCommand = new Command<PlannedMeal>(async meal => await AddMealAsync(meal));
-            RemoveMealCommand = new Command<PlannedMeal>(async meal => await RemoveMealAsync(meal));
+            AddMealCommand = new Command(async () => await Shell.Current.GoToAsync(nameof(MealFormPage)));
+            EditMealCommand = new Command<PlannedMeal>(async meal =>
+            {
+                if (meal != null)
+                    await Shell.Current.GoToAsync($"{nameof(MealFormPage)}?id={meal.Id}");
+            });
+            DeleteMealCommand = new Command<PlannedMeal>(async meal => await RemoveMealAsync(meal));
         }
 
         public async Task LoadMealsAsync(DateTime from, DateTime to)
@@ -28,15 +35,6 @@ namespace Foodbook.ViewModels
             var meals = await _plannerService.GetPlannedMealsAsync(from, to);
             foreach (var meal in meals)
                 PlannedMeals.Add(meal);
-        }
-
-        private async Task AddMealAsync(PlannedMeal meal)
-        {
-            if (meal == null)
-                return;
-
-            await _plannerService.AddPlannedMealAsync(meal);
-            PlannedMeals.Add(meal);
         }
 
         private async Task RemoveMealAsync(PlannedMeal meal)

--- a/ViewModels/RecipeViewModel.cs
+++ b/ViewModels/RecipeViewModel.cs
@@ -22,6 +22,13 @@ namespace Foodbook.ViewModels
         public RecipeViewModel(IRecipeService recipeService)
         {
             _recipeService = recipeService;
+            AddRecipeCommand = new Command(async () => await Shell.Current.GoToAsync(nameof(AddRecipePage)));
+            EditRecipeCommand = new Command<Recipe>(async r =>
+            {
+                if (r != null)
+                    await Shell.Current.GoToAsync($"{nameof(AddRecipePage)}?id={r.Id}");
+            });
+            DeleteRecipeCommand = new Command<Recipe>(async r => await DeleteRecipeAsync(r));
         }
 
         public async Task LoadRecipesAsync()
@@ -30,6 +37,13 @@ namespace Foodbook.ViewModels
             var recipes = await _recipeService.GetRecipesAsync();
             foreach (var recipe in recipes)
                 Recipes.Add(recipe);
+        }
+
+        private async Task DeleteRecipeAsync(Recipe? recipe)
+        {
+            if (recipe == null) return;
+            await _recipeService.DeleteRecipeAsync(recipe.Id);
+            Recipes.Remove(recipe);
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/Views/AddRecipePage.xaml.cs
+++ b/Views/AddRecipePage.xaml.cs
@@ -1,17 +1,33 @@
 using Microsoft.Maui.Controls;
 using Foodbook.Services;
 using Foodbook.ViewModels;
+using System.Threading.Tasks;
 
 namespace Foodbook.Views
 {
+    [QueryProperty(nameof(RecipeId), "id")]
     public partial class AddRecipePage : ContentPage
     {
         public IEnumerable<Foodbook.Models.Unit> Units => Enum.GetValues(typeof(Foodbook.Models.Unit)).Cast<Foodbook.Models.Unit>();
+
+        private AddRecipeViewModel ViewModel => BindingContext as AddRecipeViewModel;
 
         public AddRecipePage(AddRecipeViewModel vm)
         {
             InitializeComponent();
             BindingContext = vm;
+        }
+
+        private int _recipeId;
+        public int RecipeId
+        {
+            get => _recipeId;
+            set
+            {
+                _recipeId = value;
+                if (value > 0)
+                    Task.Run(async () => await ViewModel.LoadRecipeAsync(value));
+            }
         }
     }
 }

--- a/Views/IngredientFormPage.xaml
+++ b/Views/IngredientFormPage.xaml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Foodbook.Views.IngredientFormPage"
+             x:Name="ThisPage"
+             Title="Ingredient">
+    <VerticalStackLayout Padding="20" Spacing="10">
+        <Entry Placeholder="Name" Text="{Binding Name}" />
+        <Entry Placeholder="Quantity" Keyboard="Numeric" Text="{Binding Quantity}" />
+        <Picker Title="Unit" ItemsSource="{Binding Units}" SelectedItem="{Binding SelectedUnit}" />
+        <Button Text="Save" Command="{Binding SaveCommand}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/Views/IngredientFormPage.xaml.cs
+++ b/Views/IngredientFormPage.xaml.cs
@@ -1,0 +1,29 @@
+using Microsoft.Maui.Controls;
+using Foodbook.ViewModels;
+using System.Threading.Tasks;
+
+namespace Foodbook.Views;
+
+[QueryProperty(nameof(ItemId), "id")]
+public partial class IngredientFormPage : ContentPage
+{
+    private IngredientFormViewModel ViewModel => BindingContext as IngredientFormViewModel;
+
+    public IngredientFormPage(IngredientFormViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+
+    private int _itemId;
+    public int ItemId
+    {
+        get => _itemId;
+        set
+        {
+            _itemId = value;
+            if (value > 0)
+                Task.Run(async () => await ViewModel.LoadAsync(value));
+        }
+    }
+}

--- a/Views/IngredientsPage.xaml
+++ b/Views/IngredientsPage.xaml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Foodbook.Views.IngredientsPage"
+             x:Name="ThisPage"
+             Title="Ingredients">
+    <VerticalStackLayout Padding="10" Spacing="10">
+        <Button Text="Add Ingredient" Command="{Binding AddCommand}" />
+        <CollectionView ItemsSource="{Binding Ingredients}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <HorizontalStackLayout Spacing="10" Padding="5">
+                        <Label Text="{Binding Name}" />
+                        <Label Text="{Binding Quantity}" />
+                        <Label Text="{Binding Unit}" />
+                        <Button Text="Edit" Command="{Binding BindingContext.EditCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                        <Button Text="Delete" Command="{Binding BindingContext.DeleteCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                    </HorizontalStackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </VerticalStackLayout>
+</ContentPage>

--- a/Views/IngredientsPage.xaml.cs
+++ b/Views/IngredientsPage.xaml.cs
@@ -1,0 +1,22 @@
+using Microsoft.Maui.Controls;
+using Foodbook.ViewModels;
+
+namespace Foodbook.Views;
+
+public partial class IngredientsPage : ContentPage
+{
+    private readonly IngredientsViewModel _viewModel;
+
+    public IngredientsPage(IngredientsViewModel vm)
+    {
+        InitializeComponent();
+        _viewModel = vm;
+        BindingContext = _viewModel;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        await _viewModel.LoadAsync();
+    }
+}

--- a/Views/MealFormPage.xaml
+++ b/Views/MealFormPage.xaml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Foodbook.Views.MealFormPage"
+             x:Name="ThisPage"
+             Title="Plan Meal">
+    <VerticalStackLayout Padding="20" Spacing="10">
+        <DatePicker Date="{Binding Date}" />
+        <Picker Title="Recipe" ItemsSource="{Binding Recipes}" ItemDisplayBinding="{Binding Name}" SelectedItem="{Binding SelectedRecipe}" />
+        <Button Text="Save" Command="{Binding SaveCommand}" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/Views/MealFormPage.xaml.cs
+++ b/Views/MealFormPage.xaml.cs
@@ -1,0 +1,31 @@
+using Microsoft.Maui.Controls;
+using Foodbook.ViewModels;
+using System.Threading.Tasks;
+
+namespace Foodbook.Views;
+
+[QueryProperty(nameof(ItemId), "id")]
+public partial class MealFormPage : ContentPage
+{
+    private PlannedMealFormViewModel ViewModel => BindingContext as PlannedMealFormViewModel;
+
+    public MealFormPage(PlannedMealFormViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+
+    private int _itemId;
+    public int ItemId
+    {
+        get => _itemId;
+        set
+        {
+            _itemId = value;
+            if (value > 0)
+                Task.Run(async () => await ViewModel.LoadAsync(value));
+            else
+                Task.Run(async () => await ViewModel.LoadRecipesAsync());
+        }
+    }
+}

--- a/Views/PlannerPage.xaml
+++ b/Views/PlannerPage.xaml
@@ -2,10 +2,21 @@
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Foodbook.Views.PlannerPage"
+             x:Name="ThisPage"
              Title="Planner">
-    <StackLayout>
-        <Label Text="Planner Page" 
-               VerticalOptions="CenterAndExpand" 
-               HorizontalOptions="Center" />
-    </StackLayout>
+    <VerticalStackLayout Padding="10" Spacing="10">
+        <Button Text="Add" Command="{Binding AddMealCommand}" />
+        <CollectionView ItemsSource="{Binding PlannedMeals}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <HorizontalStackLayout Spacing="10">
+                        <Label Text="{Binding Recipe.Name}" />
+                        <Label Text="{Binding Date, StringFormat='{}{0:yyyy-MM-dd}'}" />
+                        <Button Text="Edit" Command="{Binding BindingContext.EditMealCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                        <Button Text="Delete" Command="{Binding BindingContext.DeleteMealCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                    </HorizontalStackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </VerticalStackLayout>
 </ContentPage>

--- a/Views/PlannerPage.xaml.cs
+++ b/Views/PlannerPage.xaml.cs
@@ -13,5 +13,11 @@ namespace Foodbook.Views
             _viewModel = viewModel;
             BindingContext = _viewModel;
         }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            await _viewModel.LoadMealsAsync(DateTime.Today.AddDays(-7), DateTime.Today.AddDays(30));
+        }
     }
 }

--- a/Views/RecipesPage.xaml
+++ b/Views/RecipesPage.xaml
@@ -5,13 +5,17 @@
              Title="Recipes">
     <StackLayout>
         <Button Text="Dodaj przepis" Clicked="OnAddRecipeClicked" Margin="10"/>
-        <CollectionView ItemsSource="{Binding Recipes}">
+        <CollectionView x:Name="ThisPage" ItemsSource="{Binding Recipes}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <Border Margin="5" Padding="10">
                         <VerticalStackLayout>
                             <Label Text="{Binding Name}" FontAttributes="Bold" FontSize="18"/>
                             <Label Text="{Binding Description}" FontSize="14" LineBreakMode="TailTruncation"/>
+                            <HorizontalStackLayout Spacing="6">
+                                <Button Text="Edit" Command="{Binding BindingContext.EditRecipeCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                                <Button Text="Delete" Command="{Binding BindingContext.DeleteRecipeCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                            </HorizontalStackLayout>
                         </VerticalStackLayout>
                     </Border>
                 </DataTemplate>


### PR DESCRIPTION
## Summary
- create ingredient service and planner service updates
- add view models for ingredients and meals
- extend recipe form to support editing
- implement ingredient and meal form pages
- update list pages with edit/delete options

## Testing
- `dotnet build -v minimal` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685c896156a4833094a2b0b046ad6406