### PR TITLE
Improve HTML parsing in RecipeImporter

### DIFF
--- a/Services/RecipeImporter.cs
+++ b/Services/RecipeImporter.cs
@@ -30,10 +30,11 @@ public class RecipeImporter
         };
 
         // 1. SKŁADNIKI
-        var ingredientHeader = doc.DocumentNode.SelectSingleNode("//h3[contains(., 'Składniki')]");
+        var ingredientHeader = doc.DocumentNode.SelectSingleNode("//h3[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZĄĆĘŁŃÓŚŹŻ','abcdefghijklmnopqrstuvwxyząćęłńóśźż'),'składniki')]");
         if (ingredientHeader != null)
         {
-            var ingredientList = ingredientHeader.SelectSingleNode("following-sibling::ul[1]");
+            // czasami lista składników jest oddzielona dodatkowymi węzłami
+            var ingredientList = ingredientHeader.SelectSingleNode("following::ul[1]");
             if (ingredientList != null)
             {
                 foreach (var li in ingredientList.SelectNodes("li"))
@@ -47,14 +48,15 @@ public class RecipeImporter
         }
 
         // 2. WARTOŚCI ODŻYWCZE
-        var nutritionHeader = doc.DocumentNode.SelectSingleNode("//h3[contains(., 'Wartości odżywcze')]");
+        var nutritionHeader = doc.DocumentNode.SelectSingleNode("//h3[contains(translate(.,'ABCDEFGHIJKLMNOPQRSTUVWXYZĄĆĘŁŃÓŚŹŻ','abcdefghijklmnopqrstuvwxyząćęłńóśźż'),'wartości odżywcze')]");
         if (nutritionHeader != null)
         {
-            var p = nutritionHeader.SelectSingleNode("following-sibling::p[1]");
+            var p = nutritionHeader.SelectSingleNode("following::p[1]");
             if (p != null)
             {
-                var lines = p.InnerHtml.Split("<br>");
-                foreach (var line in lines.Select(HtmlEntity.DeEntitize))
+                // InnerText konwertuje znaczniki <br> na nowe linie
+                var lines = HtmlEntity.DeEntitize(p.InnerText).Split('\n');
+                foreach (var line in lines)
                 {
                     var text = line.Trim();
 


### PR DESCRIPTION
## Summary
- make ingredient and nutrition headers detection case-insensitive
- allow nested nodes between header and lists
- parse nutrition info using InnerText for better <br> handling

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685d387e2ef88330ac095ca2c1b0cd4f