### PR TITLE
Improve ingredient features

### DIFF
--- a/Data/SeedData.cs
+++ b/Data/SeedData.cs
@@ -40,6 +40,16 @@ namespace Foodbook.Data
             await context.SaveChangesAsync();
         }
 
+        public static async Task SeedIngredientsAsync(AppDbContext context)
+        {
+            if (await context.Ingredients.AnyAsync())
+                return;
+
+            var ingredients = await LoadPopularIngredientsAsync();
+            context.Ingredients.AddRange(ingredients);
+            await context.SaveChangesAsync();
+        }
+
         private class IngredientInfo
         {
             public string Name { get; set; } = string.Empty;

--- a/Views/AddRecipePage.xaml
+++ b/Views/AddRecipePage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:models="clr-namespace:Foodbook.Models"
              x:Class="Foodbook.Views.AddRecipePage"
+             x:Name="ThisPage"
              Title="Dodaj przepis">
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="16">
@@ -35,7 +36,10 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
                             <HorizontalStackLayout Spacing="6">
-                                <Entry Placeholder="Nazwa" Text="{Binding Name}" WidthRequest="120" />
+                                <Picker Title="Składnik"
+                                        ItemsSource="{Binding BindingContext.IngredientNames, Source={x:Reference ThisPage}}"
+                                        SelectedItem="{Binding Name}"
+                                        WidthRequest="120" />
                                 <Entry Placeholder="Ilosc" Keyboard="Numeric" Text="{Binding Quantity}" WidthRequest="60" />
                                 <Picker Title="Jednostka"
                                         ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}"

--- a/Views/AddRecipePage.xaml.cs
+++ b/Views/AddRecipePage.xaml.cs
@@ -18,6 +18,13 @@ namespace Foodbook.Views
             BindingContext = vm;
         }
 
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            if (ViewModel != null)
+                await ViewModel.LoadIngredientNamesAsync();
+        }
+
         private int _recipeId;
         public int RecipeId
         {

--- a/Views/IngredientsPage.xaml
+++ b/Views/IngredientsPage.xaml
@@ -4,18 +4,24 @@
              x:Class="Foodbook.Views.IngredientsPage"
              x:Name="ThisPage"
              Title="Ingredients">
-    <VerticalStackLayout Padding="10" Spacing="10">
+    <VerticalStackLayout Padding="16" Spacing="12">
         <Button Text="Add Ingredient" Command="{Binding AddCommand}" />
         <CollectionView ItemsSource="{Binding Ingredients}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <HorizontalStackLayout Spacing="10" Padding="5">
-                        <Label Text="{Binding Name}" />
-                        <Label Text="{Binding Quantity}" />
-                        <Label Text="{Binding Unit}" />
-                        <Button Text="Edit" Command="{Binding BindingContext.EditCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
-                        <Button Text="Delete" Command="{Binding BindingContext.DeleteCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
-                    </HorizontalStackLayout>
+                    <Border StrokeThickness="1" Stroke="LightGray" Margin="0,4" Padding="10" StrokeShape="RoundRectangle 8">
+                        <Grid ColumnDefinitions="*,Auto" RowDefinitions="Auto">
+                            <VerticalStackLayout>
+                                <Label Text="{Binding Name}" FontAttributes="Bold" />
+                                <Label Text="{Binding Quantity}" FontSize="12"/>
+                                <Label Text="{Binding Unit}" FontSize="12"/>
+                            </VerticalStackLayout>
+                            <HorizontalStackLayout Grid.Column="1" Spacing="6" VerticalOptions="Center">
+                                <Button Text="Edit" Command="{Binding BindingContext.EditCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                                <Button Text="Delete" Command="{Binding BindingContext.DeleteCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                            </HorizontalStackLayout>
+                        </Grid>
+                    </Border>
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>

--- a/Views/IngredientsPage.xaml.cs
+++ b/Views/IngredientsPage.xaml.cs
@@ -1,5 +1,7 @@
 using Microsoft.Maui.Controls;
 using Foodbook.ViewModels;
+using Foodbook.Data;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Foodbook.Views;
 
@@ -18,5 +20,17 @@ public partial class IngredientsPage : ContentPage
     {
         base.OnAppearing();
         await _viewModel.LoadAsync();
+
+        if (_viewModel.Ingredients.Count == 0)
+        {
+            bool create = await DisplayAlert("Brak składników", "Utworzyć listę przykładowych składników?", "Tak", "Nie");
+            if (create)
+            {
+                var db = this.Handler?.MauiContext?.Services.GetService<AppDbContext>();
+                if (db != null)
+                    await SeedData.SeedIngredientsAsync(db);
+                await _viewModel.LoadAsync();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- make AddRecipe delete buttons work by naming the page
- allow choosing ingredients from saved list
- update AddRecipe to reload ingredient names
- seed default ingredients when needed
- modernize ingredient list UI
- show dialog to fill default ingredients

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d3e0bff248330bf2394517f6d252a