### PR TITLE
Improve ingredients UI and seeding

### DIFF
--- a/Data/SeedData.cs
+++ b/Data/SeedData.cs
@@ -40,6 +40,16 @@ namespace Foodbook.Data
             await context.SaveChangesAsync();
         }
 
+        public static async Task SeedIngredientsAsync(AppDbContext context)
+        {
+            if (await context.Ingredients.AnyAsync(i => i.RecipeId == 0))
+                return;
+
+            var popularIngredients = await LoadPopularIngredientsAsync();
+            context.Ingredients.AddRange(popularIngredients);
+            await context.SaveChangesAsync();
+        }
+
         private class IngredientInfo
         {
             public string Name { get; set; } = string.Empty;

--- a/ViewModels/AddRecipeViewModel.cs
+++ b/ViewModels/AddRecipeViewModel.cs
@@ -62,11 +62,15 @@ namespace Foodbook.ViewModels
         public ICommand SetImportModeCommand { get; }
 
         private readonly IRecipeService _recipeService;
+        private readonly IIngredientService _ingredientService;
         private readonly RecipeImporter _importer;
 
-        public AddRecipeViewModel(IRecipeService recipeService, RecipeImporter importer)
+        public ObservableCollection<string> IngredientOptions { get; } = new();
+
+        public AddRecipeViewModel(IRecipeService recipeService, IIngredientService ingredientService, RecipeImporter importer)
         {
             _recipeService = recipeService ?? throw new ArgumentNullException(nameof(recipeService));
+            _ingredientService = ingredientService ?? throw new ArgumentNullException(nameof(ingredientService));
             _importer = importer ?? throw new ArgumentNullException(nameof(importer));
 
             AddIngredientCommand = new Command(AddIngredient);
@@ -95,9 +99,18 @@ namespace Foodbook.ViewModels
                 Ingredients.Add(new Ingredient { Id = ing.Id, Name = ing.Name, Quantity = ing.Quantity, Unit = ing.Unit, RecipeId = ing.RecipeId });
         }
 
+        public async Task LoadIngredientOptionsAsync()
+        {
+            IngredientOptions.Clear();
+            var list = await _ingredientService.GetIngredientsAsync();
+            foreach (var ing in list)
+                IngredientOptions.Add(ing.Name);
+        }
+
         private void AddIngredient()
         {
-            Ingredients.Add(new Ingredient { Name = "", Quantity = 0, Unit = Unit.Gram });
+            var defaultName = IngredientOptions.FirstOrDefault() ?? string.Empty;
+            Ingredients.Add(new Ingredient { Name = defaultName, Quantity = 0, Unit = Unit.Gram });
         }
 
         private void RemoveIngredient(Ingredient ingredient)

--- a/Views/AddRecipePage.xaml
+++ b/Views/AddRecipePage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:models="clr-namespace:Foodbook.Models"
              x:Class="Foodbook.Views.AddRecipePage"
+             x:Name="ThisPage"
              Title="Dodaj przepis">
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="16">
@@ -21,30 +22,38 @@
                 <Label Text="{Binding ImportStatus}" TextColor="Gray" FontSize="12" />
             </StackLayout>
 
-            <!-- Tryb reczny -->    
+            <!-- Tryb reczny -->
             <StackLayout IsVisible="{Binding IsManualMode}">
-                <Entry Placeholder="Nazwa przepisu" Text="{Binding Name}" />
-                <Editor Placeholder="Opis" Text="{Binding Description}" AutoSize="TextChanges" />
-                <Entry Placeholder="Kalorie" Keyboard="Numeric" Text="{Binding Calories}" />
-                <Entry Placeholder="Bialko" Keyboard="Numeric" Text="{Binding Protein}" />
-                <Entry Placeholder="Tluszcze" Keyboard="Numeric" Text="{Binding Fat}" />
-                <Entry Placeholder="Weglowodany" Keyboard="Numeric" Text="{Binding Carbs}" />
+                <Frame Padding="10" Margin="0,4" BorderColor="LightGray" CornerRadius="8">
+                    <VerticalStackLayout Spacing="8">
+                        <Entry Placeholder="Nazwa przepisu" Text="{Binding Name}" />
+                        <Editor Placeholder="Opis" Text="{Binding Description}" AutoSize="TextChanges" />
+                        <Entry Placeholder="Kalorie" Keyboard="Numeric" Text="{Binding Calories}" />
+                        <Entry Placeholder="Bialko" Keyboard="Numeric" Text="{Binding Protein}" />
+                        <Entry Placeholder="Tluszcze" Keyboard="Numeric" Text="{Binding Fat}" />
+                        <Entry Placeholder="Weglowodany" Keyboard="Numeric" Text="{Binding Carbs}" />
+                    </VerticalStackLayout>
+                </Frame>
 
                 <Label Text="Skladniki:" FontAttributes="Bold" />
                 <CollectionView ItemsSource="{Binding Ingredients}">
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
-                            <HorizontalStackLayout Spacing="6">
-                                <Entry Placeholder="Nazwa" Text="{Binding Name}" WidthRequest="120" />
-                                <Entry Placeholder="Ilosc" Keyboard="Numeric" Text="{Binding Quantity}" WidthRequest="60" />
-                                <Picker Title="Jednostka"
-                                        ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}"
-                                        SelectedItem="{Binding Unit}"
-                                        WidthRequest="100" />
-                                <Button Text="Usun"
-                                        Command="{Binding BindingContext.RemoveIngredientCommand, Source={x:Reference ThisPage}}"
-                                        CommandParameter="{Binding .}" />
-                            </HorizontalStackLayout>
+                            <Frame Padding="8" Margin="0,4" BorderColor="LightGray" CornerRadius="8">
+                                <HorizontalStackLayout Spacing="6">
+                                    <Picker Title="Składnik"
+                                            ItemsSource="{Binding BindingContext.IngredientOptions, Source={x:Reference ThisPage}}"
+                                            SelectedItem="{Binding Name}" WidthRequest="120" />
+                                    <Entry Placeholder="Ilosc" Keyboard="Numeric" Text="{Binding Quantity}" WidthRequest="60" />
+                                    <Picker Title="Jednostka"
+                                            ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}"
+                                            SelectedItem="{Binding Unit}"
+                                            WidthRequest="100" />
+                                    <Button Text="Usun"
+                                            Command="{Binding BindingContext.RemoveIngredientCommand, Source={x:Reference ThisPage}}"
+                                            CommandParameter="{Binding .}" />
+                                </HorizontalStackLayout>
+                            </Frame>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>

--- a/Views/AddRecipePage.xaml.cs
+++ b/Views/AddRecipePage.xaml.cs
@@ -29,5 +29,11 @@ namespace Foodbook.Views
                     Task.Run(async () => await ViewModel.LoadRecipeAsync(value));
             }
         }
+
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            await ViewModel.LoadIngredientOptionsAsync();
+        }
     }
 }

--- a/Views/IngredientsPage.xaml
+++ b/Views/IngredientsPage.xaml
@@ -9,13 +9,15 @@
         <CollectionView ItemsSource="{Binding Ingredients}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
-                    <HorizontalStackLayout Spacing="10" Padding="5">
-                        <Label Text="{Binding Name}" />
-                        <Label Text="{Binding Quantity}" />
-                        <Label Text="{Binding Unit}" />
-                        <Button Text="Edit" Command="{Binding BindingContext.EditCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
-                        <Button Text="Delete" Command="{Binding BindingContext.DeleteCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
-                    </HorizontalStackLayout>
+                    <Frame Padding="8" Margin="0,4" BorderColor="LightGray" CornerRadius="8">
+                        <HorizontalStackLayout Spacing="10" Padding="5">
+                            <Label Text="{Binding Name}" />
+                            <Label Text="{Binding Quantity}" />
+                            <Label Text="{Binding Unit}" />
+                            <Button Text="Edit" Command="{Binding BindingContext.EditCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                            <Button Text="Delete" Command="{Binding BindingContext.DeleteCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                        </HorizontalStackLayout>
+                    </Frame>
                 </DataTemplate>
             </CollectionView.ItemTemplate>
         </CollectionView>

--- a/Views/IngredientsPage.xaml.cs
+++ b/Views/IngredientsPage.xaml.cs
@@ -1,16 +1,19 @@
 using Microsoft.Maui.Controls;
 using Foodbook.ViewModels;
+using Foodbook.Data;
 
 namespace Foodbook.Views;
 
 public partial class IngredientsPage : ContentPage
 {
     private readonly IngredientsViewModel _viewModel;
+    private readonly AppDbContext _db;
 
-    public IngredientsPage(IngredientsViewModel vm)
+    public IngredientsPage(IngredientsViewModel vm, AppDbContext db)
     {
         InitializeComponent();
         _viewModel = vm;
+        _db = db;
         BindingContext = _viewModel;
     }
 
@@ -18,5 +21,14 @@ public partial class IngredientsPage : ContentPage
     {
         base.OnAppearing();
         await _viewModel.LoadAsync();
+        if (_viewModel.Ingredients.Count == 0)
+        {
+            bool seed = await DisplayAlert("Brak składników", "Utworzyć listę przykładowych składników?", "Tak", "Nie");
+            if (seed)
+            {
+                await SeedData.SeedIngredientsAsync(_db);
+                await _viewModel.LoadAsync();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- modernise Add Recipe UI and fix remove button by naming the page
- pull ingredient names from stored ingredients when creating a recipe
- add dialog on Ingredients page to optionally seed example data
- include new method to seed ingredients independently

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d3e0bff248330bf2394517f6d252a