### PR TITLE
Improve ingredient seeding

### DIFF
--- a/Data/AppDbContext.cs
+++ b/Data/AppDbContext.cs
@@ -19,6 +19,10 @@ namespace Foodbook.Data
                 .HasForeignKey(i => i.RecipeId)
                 .OnDelete(DeleteBehavior.Cascade);
 
+            modelBuilder.Entity<Ingredient>()
+                .Property(i => i.RecipeId)
+                .IsRequired(false);
+
             modelBuilder.Entity<PlannedMeal>()
                 .HasOne(pm => pm.Recipe)
                 .WithMany()

--- a/Data/SeedData.cs
+++ b/Data/SeedData.cs
@@ -11,6 +11,8 @@ namespace Foodbook.Data
     {
         public static async Task InitializeAsync(AppDbContext context)
         {
+            await SeedIngredientsAsync(context);
+
             if (await context.Recipes.AnyAsync())
                 return;
 
@@ -28,15 +30,18 @@ namespace Foodbook.Data
                     new Ingredient { Name = "Pomidor", Quantity = 50, Unit = Unit.Gram }
                 }
             };
-            // Seed popular ingredients from embedded JSON (if not already added)
-            if (!await context.Ingredients.AnyAsync(i => i.RecipeId == 0))
-            {
-                var popularIngredients = await LoadPopularIngredientsAsync();
-                context.Ingredients.AddRange(popularIngredients);
-            }
 
-            
             context.Recipes.Add(recipe);
+            await context.SaveChangesAsync();
+        }
+
+        public static async Task SeedIngredientsAsync(AppDbContext context)
+        {
+            if (await context.Ingredients.AnyAsync(i => i.RecipeId == null))
+                return;
+
+            var ingredients = await LoadPopularIngredientsAsync();
+            context.Ingredients.AddRange(ingredients);
             await context.SaveChangesAsync();
         }
 

--- a/FoodbookApp.csproj
+++ b/FoodbookApp.csproj
@@ -55,8 +55,10 @@
 		<!-- Custom Fonts -->
 		<MauiFont Include="Resources\Fonts\*" />
 
-		<!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
-		<MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+                <!-- Raw Assets (also remove the "Resources\Raw" prefix) -->
+                <MauiAsset Include="Resources\Raw\**" LogicalName="%(RecursiveDir)%(Filename)%(Extension)" />
+                <!-- JSON Data -->
+                <MauiAsset Include="Resources\Data\**" LogicalName="Data/%(RecursiveDir)%(Filename)%(Extension)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -12,6 +12,7 @@ namespace FoodbookApp
 {
     public static class MauiProgram
     {
+        public static IServiceProvider? ServiceProvider { get; private set; }
         public static MauiApp CreateMauiApp()
         {
             var builder = MauiApp.CreateBuilder();
@@ -72,6 +73,7 @@ namespace FoodbookApp
 
             // ✨ Build aplikacji
             var app = builder.Build();
+            ServiceProvider = app.Services;
 
             // 📦 Inicjalizacja bazy danych
             using (var scope = app.Services.CreateScope())

--- a/Models/Ingredient.cs
+++ b/Models/Ingredient.cs
@@ -14,7 +14,7 @@ namespace Foodbook.Models
         public double Quantity { get; set; }
         public Unit Unit { get; set; }
 
-        public int RecipeId { get; set; }
+        public int? RecipeId { get; set; }
         public Recipe? Recipe { get; set; }
     }
 }

--- a/Services/IngredientService.cs
+++ b/Services/IngredientService.cs
@@ -12,7 +12,7 @@ public class IngredientService : IIngredientService
         _context = context;
     }
 
-    public async Task<List<Ingredient>> GetIngredientsAsync() => await _context.Ingredients.Where(i => i.RecipeId == 0).ToListAsync();
+    public async Task<List<Ingredient>> GetIngredientsAsync() => await _context.Ingredients.Where(i => i.RecipeId == null).ToListAsync();
 
     public async Task<Ingredient?> GetIngredientAsync(int id) => await _context.Ingredients.FindAsync(id);
 

--- a/ViewModels/AddRecipeViewModel.cs
+++ b/ViewModels/AddRecipeViewModel.cs
@@ -62,11 +62,13 @@ namespace Foodbook.ViewModels
         public ICommand SetImportModeCommand { get; }
 
         private readonly IRecipeService _recipeService;
+        private readonly IIngredientService _ingredientService;
         private readonly RecipeImporter _importer;
 
-        public AddRecipeViewModel(IRecipeService recipeService, RecipeImporter importer)
+        public AddRecipeViewModel(IRecipeService recipeService, IIngredientService ingredientService, RecipeImporter importer)
         {
             _recipeService = recipeService ?? throw new ArgumentNullException(nameof(recipeService));
+            _ingredientService = ingredientService ?? throw new ArgumentNullException(nameof(ingredientService));
             _importer = importer ?? throw new ArgumentNullException(nameof(importer));
 
             AddIngredientCommand = new Command(AddIngredient);
@@ -97,7 +99,8 @@ namespace Foodbook.ViewModels
 
         private void AddIngredient()
         {
-            Ingredients.Add(new Ingredient { Name = "", Quantity = 0, Unit = Unit.Gram });
+            var name = AvailableIngredientNames.FirstOrDefault() ?? string.Empty;
+            Ingredients.Add(new Ingredient { Name = name, Quantity = 0, Unit = Unit.Gram });
         }
 
         private void RemoveIngredient(Ingredient ingredient)
@@ -134,8 +137,6 @@ namespace Foodbook.ViewModels
 
         private async Task SaveRecipeAsync()
         {
-            foreach (var ing in Ingredients)
-                ing.RecipeId = 0;
 
             var recipe = _editingRecipe ?? new Recipe();
             recipe.Name = Name;
@@ -166,8 +167,17 @@ namespace Foodbook.ViewModels
             await Shell.Current.GoToAsync("..");
         }
 
-        // Add this property for Picker ItemsSource
+        // Dostępne jednostki i lista nazw składników
         public IEnumerable<Unit> Units { get; } = Enum.GetValues(typeof(Unit)).Cast<Unit>();
+        public ObservableCollection<string> AvailableIngredientNames { get; } = new();
+
+        public async Task LoadAvailableIngredientsAsync()
+        {
+            AvailableIngredientNames.Clear();
+            var list = await _ingredientService.GetIngredientsAsync();
+            foreach (var ing in list)
+                AvailableIngredientNames.Add(ing.Name);
+        }
 
         public event PropertyChangedEventHandler PropertyChanged;
         void OnPropertyChanged([CallerMemberName] string name = null) =>

--- a/Views/AddRecipePage.xaml
+++ b/Views/AddRecipePage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:models="clr-namespace:Foodbook.Models"
              x:Class="Foodbook.Views.AddRecipePage"
+             x:Name="ThisPage"
              Title="Dodaj przepis">
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="16">
@@ -34,17 +35,22 @@
                 <CollectionView ItemsSource="{Binding Ingredients}">
                     <CollectionView.ItemTemplate>
                         <DataTemplate>
-                            <HorizontalStackLayout Spacing="6">
-                                <Entry Placeholder="Nazwa" Text="{Binding Name}" WidthRequest="120" />
-                                <Entry Placeholder="Ilosc" Keyboard="Numeric" Text="{Binding Quantity}" WidthRequest="60" />
-                                <Picker Title="Jednostka"
-                                        ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}"
-                                        SelectedItem="{Binding Unit}"
-                                        WidthRequest="100" />
-                                <Button Text="Usun"
-                                        Command="{Binding BindingContext.RemoveIngredientCommand, Source={x:Reference ThisPage}}"
-                                        CommandParameter="{Binding .}" />
-                            </HorizontalStackLayout>
+                            <Border StrokeThickness="1" Stroke="LightGray" Padding="6" Margin="2">
+                                <Grid ColumnDefinitions="*,Auto,Auto,Auto" ColumnSpacing="6">
+                                    <Picker Title="Składnik"
+                                            ItemsSource="{Binding BindingContext.AvailableIngredientNames, Source={x:Reference ThisPage}}"
+                                            SelectedItem="{Binding Name}"
+                                            WidthRequest="120" />
+                                    <Entry Grid.Column="1" Placeholder="Ilosc" Keyboard="Numeric" Text="{Binding Quantity}" WidthRequest="60" />
+                                    <Picker Grid.Column="2" Title="Jednostka"
+                                            ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}"
+                                            SelectedItem="{Binding Unit}"
+                                            WidthRequest="100" />
+                                    <Button Grid.Column="3" Text="Usun"
+                                            Command="{Binding BindingContext.RemoveIngredientCommand, Source={x:Reference ThisPage}}"
+                                            CommandParameter="{Binding .}" />
+                                </Grid>
+                            </Border>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                 </CollectionView>

--- a/Views/AddRecipePage.xaml.cs
+++ b/Views/AddRecipePage.xaml.cs
@@ -18,6 +18,12 @@ namespace Foodbook.Views
             BindingContext = vm;
         }
 
+        protected override async void OnAppearing()
+        {
+            base.OnAppearing();
+            await ViewModel.LoadAvailableIngredientsAsync();
+        }
+
         private int _recipeId;
         public int RecipeId
         {

--- a/Views/IngredientsPage.xaml.cs
+++ b/Views/IngredientsPage.xaml.cs
@@ -1,5 +1,7 @@
 using Microsoft.Maui.Controls;
 using Foodbook.ViewModels;
+using Foodbook.Data;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Foodbook.Views;
 
@@ -18,5 +20,17 @@ public partial class IngredientsPage : ContentPage
     {
         base.OnAppearing();
         await _viewModel.LoadAsync();
+
+        if (_viewModel.Ingredients.Count == 0)
+        {
+            bool create = await DisplayAlert("Brak składników", "Utworzyć listę przykładowych składników?", "Tak", "Nie");
+            if (create && MauiProgram.ServiceProvider != null)
+            {
+                using var scope = MauiProgram.ServiceProvider.CreateScope();
+                var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+                await SeedData.SeedIngredientsAsync(db);
+                await _viewModel.LoadAsync();
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add json data folder to build assets
- make ingredient RecipeId optional
- adjust DB context and service queries
- remove leftover RecipeId assignments

## Testing
- `dotnet build --no-restore` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685d3e0bff248330bf2394517f6d252a