### PR TITLE
Add planner period settings and dynamic grid UI

### DIFF
--- a/Models/PlannedMeal.cs
+++ b/Models/PlannedMeal.cs
@@ -8,5 +8,6 @@ namespace Foodbook.Models
         public int RecipeId { get; set; }
         public Recipe? Recipe { get; set; }
         public DateTime Date { get; set; }
+        public int Portions { get; set; } = 1;
     }
 }

--- a/Models/PlannerDay.cs
+++ b/Models/PlannerDay.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.ObjectModel;
+
+namespace Foodbook.Models
+{
+    public class PlannerDay
+    {
+        public DateTime Date { get; }
+        public ObservableCollection<PlannedMeal> Meals { get; } = new();
+
+        public PlannerDay(DateTime date)
+        {
+            Date = date;
+        }
+    }
+}

--- a/Services/ShoppingListService.cs
+++ b/Services/ShoppingListService.cs
@@ -22,7 +22,14 @@ public class ShoppingListService : IShoppingListService
             .ToListAsync();
 
         var ingredients = meals
-            .SelectMany(pm => pm.Recipe?.Ingredients ?? Enumerable.Empty<Ingredient>());
+            .SelectMany(pm =>
+                (pm.Recipe?.Ingredients ?? Enumerable.Empty<Ingredient>())
+                .Select(i => new Ingredient
+                {
+                    Name = i.Name,
+                    Unit = i.Unit,
+                    Quantity = i.Quantity * pm.Portions
+                }));
 
         var grouped = ingredients
             .GroupBy(i => new { i.Name, i.Unit })

--- a/Views/PlannerPage.xaml
+++ b/Views/PlannerPage.xaml
@@ -1,22 +1,48 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:models="clr-namespace:Foodbook.Models"
              x:Class="Foodbook.Views.PlannerPage"
              x:Name="ThisPage"
              Title="Planner">
-    <VerticalStackLayout Padding="10" Spacing="10">
-        <Button Text="Add" Command="{Binding AddMealCommand}" />
-        <CollectionView ItemsSource="{Binding PlannedMeals}">
-            <CollectionView.ItemTemplate>
-                <DataTemplate>
-                    <HorizontalStackLayout Spacing="10">
-                        <Label Text="{Binding Recipe.Name}" />
-                        <Label Text="{Binding Date, StringFormat='{}{0:yyyy-MM-dd}'}" />
-                        <Button Text="Edit" Command="{Binding BindingContext.EditMealCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
-                        <Button Text="Delete" Command="{Binding BindingContext.DeleteMealCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
-                    </HorizontalStackLayout>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
-    </VerticalStackLayout>
+    <ScrollView>
+        <VerticalStackLayout Padding="10" Spacing="10">
+            <HorizontalStackLayout>
+                <Label Text="Start:" VerticalOptions="Center" />
+                <DatePicker Date="{Binding StartDate}" />
+                <Label Text="Koniec:" VerticalOptions="Center" />
+                <DatePicker Date="{Binding EndDate}" />
+            </HorizontalStackLayout>
+            <HorizontalStackLayout>
+                <Label Text="Posiłków/dzień:" VerticalOptions="Center" />
+                <Entry Text="{Binding MealsPerDay}" Keyboard="Numeric" WidthRequest="60" />
+            </HorizontalStackLayout>
+            <VerticalStackLayout BindableLayout.ItemsSource="{Binding Days}">
+                <BindableLayout.ItemTemplate>
+                    <DataTemplate>
+                        <VerticalStackLayout>
+                            <Label Text="{Binding Date, StringFormat='{}{0:yyyy-MM-dd}'}" FontAttributes="Bold" />
+                            <StackLayout BindableLayout.ItemsSource="{Binding Meals}">
+                                <BindableLayout.ItemTemplate>
+                                    <DataTemplate>
+                                        <HorizontalStackLayout Spacing="5" VerticalOptions="Center">
+                                            <Picker ItemsSource="{Binding Source={x:Reference ThisPage}, Path=BindingContext.Recipes}" ItemDisplayBinding="{Binding Name}" SelectedItem="{Binding Recipe}" />
+                                            <Entry Text="{Binding Portions}" Keyboard="Numeric" WidthRequest="50" />
+                                            <Button Text="-" Command="{Binding BindingContext.RemoveMealCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                                        </HorizontalStackLayout>
+                                    </DataTemplate>
+                                </BindableLayout.ItemTemplate>
+                            </StackLayout>
+                            <Button Text="Dodaj posiłek" Command="{Binding BindingContext.AddMealCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                        </VerticalStackLayout>
+                    </DataTemplate>
+                </BindableLayout.ItemTemplate>
+            </VerticalStackLayout>
+            <HorizontalStackLayout Spacing="10" Margin="0,20,0,0">
+                <Button Text="Zapisz" Command="{Binding SaveCommand}" />
+                <Button Text="Zapisz i stwórz listę" Command="{Binding SaveAndListCommand}" />
+                <Button Text="Anuluj" Command="{Binding CancelCommand}" />
+            </HorizontalStackLayout>
+        </VerticalStackLayout>
+    </ScrollView>
 </ContentPage>

--- a/Views/PlannerPage.xaml.cs
+++ b/Views/PlannerPage.xaml.cs
@@ -17,7 +17,7 @@ namespace Foodbook.Views
         protected override async void OnAppearing()
         {
             base.OnAppearing();
-            await _viewModel.LoadMealsAsync(DateTime.Today.AddDays(-7), DateTime.Today.AddDays(30));
+            await _viewModel.LoadAsync();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add portion count field to `PlannedMeal`
- support planner view over a date range with `PlannerDay` helper
- update shopping list to multiply ingredient quantities by meal portions
- implement new planner view model with start/end dates and meals per day
- redesign planner page with dynamic grid editing and save actions

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_685d8bf71fb88330ad303ffa40f7f92c