### PR TITLE
Fix planner updates and recipe editing concurrency

### DIFF
--- a/ViewModels/PlannerViewModel.cs
+++ b/ViewModels/PlannerViewModel.cs
@@ -18,6 +18,8 @@ public class PlannerViewModel : INotifyPropertyChanged
     public ObservableCollection<Recipe> Recipes { get; } = new();
     public ObservableCollection<PlannerDay> Days { get; } = new();
 
+    private bool _isLoading;
+
     private DateTime _startDate = DateTime.Today;
     public DateTime StartDate
     {
@@ -27,7 +29,7 @@ public class PlannerViewModel : INotifyPropertyChanged
             if (_startDate == value) return;
             _startDate = value;
             OnPropertyChanged();
-            Task.Run(async () => await LoadAsync());
+            _ = LoadAsync();
         }
     }
 
@@ -40,7 +42,7 @@ public class PlannerViewModel : INotifyPropertyChanged
             if (_endDate == value) return;
             _endDate = value;
             OnPropertyChanged();
-            Task.Run(async () => await LoadAsync());
+            _ = LoadAsync();
         }
     }
 
@@ -78,6 +80,10 @@ public class PlannerViewModel : INotifyPropertyChanged
 
     public async Task LoadAsync()
     {
+        if (_isLoading)
+            return;
+        _isLoading = true;
+
         Days.Clear();
         Recipes.Clear();
 
@@ -95,6 +101,8 @@ public class PlannerViewModel : INotifyPropertyChanged
             Days.Add(day);
         }
         AdjustMealsPerDay();
+
+        _isLoading = false;
     }
 
     private void AddMeal(PlannerDay? day)

--- a/Views/AddRecipePage.xaml.cs
+++ b/Views/AddRecipePage.xaml.cs
@@ -22,18 +22,15 @@ namespace Foodbook.Views
         {
             base.OnAppearing();
             await ViewModel.LoadAvailableIngredientsAsync();
+            if (RecipeId > 0)
+                await ViewModel.LoadRecipeAsync(RecipeId);
         }
 
         private int _recipeId;
         public int RecipeId
         {
             get => _recipeId;
-            set
-            {
-                _recipeId = value;
-                if (value > 0)
-                    Task.Run(async () => await ViewModel.LoadRecipeAsync(value));
-            }
+            set => _recipeId = value;
         }
 
         protected override bool OnBackButtonPressed()


### PR DESCRIPTION
## Summary
- ensure AddRecipePage loads recipe sequentially
- update PlannerViewModel to refresh days when date changes
- prevent overlapping planner loads

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d9ea744cc8330ac47e0f7640a151b