### PR TITLE
Fix database initialization

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -84,7 +84,7 @@ namespace FoodbookApp
             {
                 var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
                 db.Database.EnsureCreated();
-                Task.Run(async () => await SeedData.InitializeAsync(db)).Wait();
+                SeedData.InitializeAsync(db).GetAwaiter().GetResult();
             }
 
             return app;


### PR DESCRIPTION
## Summary
- initialize database without Task.Run(...).Wait() to prevent deadlocks

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685db5bd9c148330938686aa096f8e3e