### PR TITLE
Fix async load in SeedData

### DIFF
--- a/Data/SeedData.cs
+++ b/Data/SeedData.cs
@@ -124,8 +124,8 @@ namespace Foodbook.Data
                     // Metoda 3: Próba tradycyjnego odczytu pliku
                     try
                     {
-                        var appDir = FileSystem.Current.OpenAppPackageFileAsync("ingredients.json").Result;
-                        using var reader = new StreamReader(appDir);
+                        using var stream = await FileSystem.Current.OpenAppPackageFileAsync("ingredients.json");
+                        using var reader = new StreamReader(stream);
                         json = await reader.ReadToEndAsync();
                     }
                     catch


### PR DESCRIPTION
## Summary
- keep `LoadPopularIngredientsAsync` fully asynchronous

## Testing
- `dotnet build FoodbookApp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685dccbb482c8330851119e8a9dfc4c5