### PR TITLE
Improve planner reset and shopping list editing

### DIFF
--- a/ViewModels/PlannerViewModel.cs
+++ b/ViewModels/PlannerViewModel.cs
@@ -93,13 +93,9 @@ public class PlannerViewModel : INotifyPropertyChanged
         foreach (var r in rec)
             Recipes.Add(r);
 
-        var meals = await _plannerService.GetPlannedMealsAsync(StartDate, EndDate);
-
         for (var d = StartDate.Date; d <= EndDate.Date; d = d.AddDays(1))
         {
             var day = new PlannerDay(d);
-            foreach (var m in meals.Where(m => m.Date.Date == d))
-                day.Meals.Add(m);
             Days.Add(day);
         }
         AdjustMealsPerDay();

--- a/ViewModels/ShoppingListDetailViewModel.cs
+++ b/ViewModels/ShoppingListDetailViewModel.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.ObjectModel;
+using System.Windows.Input;
 using Foodbook.Models;
 using Foodbook.Services;
 
@@ -10,11 +12,18 @@ public class ShoppingListDetailViewModel
     private readonly IPlanService _planService;
 
     public ObservableCollection<Ingredient> Items { get; } = new();
+    public IEnumerable<Unit> Units => Enum.GetValues(typeof(Unit)).Cast<Unit>();
+
+    public ICommand AddItemCommand { get; }
+    public ICommand RemoveItemCommand { get; }
 
     public ShoppingListDetailViewModel(IShoppingListService shoppingListService, IPlanService planService)
     {
         _shoppingListService = shoppingListService;
         _planService = planService;
+
+        AddItemCommand = new Command(AddItem);
+        RemoveItemCommand = new Command<Ingredient>(RemoveItem);
     }
 
     public async Task LoadAsync(int planId)
@@ -26,5 +35,16 @@ public class ShoppingListDetailViewModel
         Items.Clear();
         foreach (var item in items)
             Items.Add(item);
+    }
+
+    private void AddItem()
+    {
+        Items.Add(new Ingredient { Name = string.Empty, Quantity = 0, Unit = Unit.Gram });
+    }
+
+    private void RemoveItem(Ingredient? item)
+    {
+        if (item == null) return;
+        Items.Remove(item);
     }
 }

--- a/Views/PlannerPage.xaml
+++ b/Views/PlannerPage.xaml
@@ -42,9 +42,7 @@
                 </BindableLayout.ItemTemplate>
             </VerticalStackLayout>
             <HorizontalStackLayout Spacing="10" Margin="0,20,0,0">
-                <Button Text="Zapisz" Command="{Binding SaveCommand}" />
                 <Button Text="Zapisz i stwórz listę" Command="{Binding SaveAndListCommand}" />
-                <Button Text="Anuluj" Command="{Binding CancelCommand}" />
             </HorizontalStackLayout>
         </VerticalStackLayout>
     </ScrollView>

--- a/Views/PlannerPage.xaml.cs
+++ b/Views/PlannerPage.xaml.cs
@@ -19,5 +19,12 @@ namespace Foodbook.Views
             base.OnAppearing();
             await _viewModel.LoadAsync();
         }
+
+        protected override bool OnBackButtonPressed()
+        {
+            if (_viewModel?.CancelCommand?.CanExecute(null) == true)
+                _viewModel.CancelCommand.Execute(null);
+            return true;
+        }
     }
 }

--- a/Views/ShoppingListDetailPage.xaml
+++ b/Views/ShoppingListDetailPage.xaml
@@ -4,17 +4,22 @@
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              x:Class="Foodbook.Views.ShoppingListDetailPage"
+             x:Name="ThisPage"
              x:DataType="vm:ShoppingListDetailViewModel"
              Title="Shopping List">
-    <CollectionView ItemsSource="{Binding Items}" Margin="10">
-        <CollectionView.ItemTemplate>
-            <DataTemplate x:DataType="models:Ingredient">
-                <Grid ColumnDefinitions="2*,Auto,Auto" Padding="5">
-                    <Label Text="{Binding Name}" Grid.Column="0" />
-                    <Label Text="{Binding Quantity}" Grid.Column="1" />
-                    <Label Text="{Binding Unit}" Grid.Column="2" />
-                </Grid>
-            </DataTemplate>
-        </CollectionView.ItemTemplate>
-    </CollectionView>
+    <StackLayout Padding="10" Spacing="10">
+        <CollectionView ItemsSource="{Binding Items}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="models:Ingredient">
+                    <Grid ColumnDefinitions="2*,Auto,Auto,Auto" Padding="5" ColumnSpacing="5">
+                        <Entry Text="{Binding Name}" Placeholder="Nazwa" Grid.Column="0" />
+                        <Entry Text="{Binding Quantity}" Keyboard="Numeric" WidthRequest="60" Grid.Column="1" />
+                        <Picker Grid.Column="2" WidthRequest="80" ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}" SelectedItem="{Binding Unit}" />
+                        <Button Grid.Column="3" Text="Usuń" Command="{Binding BindingContext.RemoveItemCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Button Text="Dodaj składnik" Command="{Binding AddItemCommand}" />
+    </StackLayout>
 </ContentPage>

--- a/Views/ShoppingListDetailPage.xaml.cs
+++ b/Views/ShoppingListDetailPage.xaml.cs
@@ -22,4 +22,10 @@ public partial class ShoppingListDetailPage : ContentPage
         base.OnAppearing();
         await _viewModel.LoadAsync(PlanId);
     }
+
+    protected override bool OnBackButtonPressed()
+    {
+        Shell.Current.GoToAsync("..");
+        return true;
+    }
 }


### PR DESCRIPTION
## Summary
- clear planner view after saving instead of loading saved meals
- remove cancel and extra save buttons from planner UI
- add back arrow handling to planner page
- enable editing shopping lists with add/remove item commands
- show editable entries for shopping list items

## Testing
- `dotnet build FoodbookApp.sln -v:m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685fdc33cc588330938cff8e209f118b