### PR TITLE
UI tweaks for planner and lists

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -8,19 +8,19 @@
 
     <TabBar>
         <ShellContent
-            Title="Home"
+            Title="Start"
             ContentTemplate="{DataTemplate views:HomePage}" />
         <ShellContent
-            Title="Recipes"
+            Title="Przepisy"
             ContentTemplate="{DataTemplate views:RecipesPage}" />
         <ShellContent
-            Title="Ingredients"
+            Title="Składniki"
             ContentTemplate="{DataTemplate views:IngredientsPage}" />
         <ShellContent
-            Title="Planner"
+            Title="Planer"
             ContentTemplate="{DataTemplate views:PlannerPage}" />
         <ShellContent
-            Title="Shopping List"
+            Title="Listy zakupów"
             ContentTemplate="{DataTemplate views:ShoppingListPage}" />
     </TabBar>
 

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -45,6 +45,7 @@ namespace FoodbookApp
             builder.Services.AddScoped<RecipeViewModel>();
             builder.Services.AddScoped<AddRecipeViewModel>();
             builder.Services.AddScoped<PlannerViewModel>();
+            builder.Services.AddScoped<HomeViewModel>();
             builder.Services.AddScoped<ShoppingListViewModel>();
             builder.Services.AddScoped<ShoppingListDetailViewModel>();
             builder.Services.AddScoped<IngredientsViewModel>();
@@ -57,6 +58,7 @@ namespace FoodbookApp
 
             // 🧭 Rejestracja widoków (Pages), jeśli używasz DI do ich tworzenia
             builder.Services.AddScoped<RecipesPage>();
+            builder.Services.AddScoped<HomePage>();
             builder.Services.AddScoped<AddRecipePage>();
             builder.Services.AddScoped<IngredientsPage>();
             builder.Services.AddScoped<IngredientFormPage>();
@@ -74,6 +76,7 @@ namespace FoodbookApp
             Routing.RegisterRoute(nameof(MealFormPage), typeof(MealFormPage));
             Routing.RegisterRoute(nameof(ShoppingListPage), typeof(ShoppingListPage));
             Routing.RegisterRoute(nameof(ShoppingListDetailPage), typeof(ShoppingListDetailPage));
+            Routing.RegisterRoute(nameof(HomePage), typeof(HomePage));
 
             // ✨ Build aplikacji
             var app = builder.Build();

--- a/Models/Ingredient.cs
+++ b/Models/Ingredient.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
 namespace Foodbook.Models
 {
     public enum Unit
@@ -13,6 +15,9 @@ namespace Foodbook.Models
         public string Name { get; set; } = string.Empty;
         public double Quantity { get; set; }
         public Unit Unit { get; set; }
+
+        [NotMapped]
+        public bool IsChecked { get; set; }
 
         // Nutritional information per specified amount/unit
         public double Calories { get; set; }

--- a/ViewModels/HomeViewModel.cs
+++ b/ViewModels/HomeViewModel.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Foodbook.Services;
+
+namespace Foodbook.ViewModels;
+
+public class HomeViewModel : INotifyPropertyChanged
+{
+    private readonly IRecipeService _recipeService;
+    private readonly IPlanService _planService;
+
+    private int _recipeCount;
+    public int RecipeCount
+    {
+        get => _recipeCount;
+        set { if (_recipeCount != value) { _recipeCount = value; OnPropertyChanged(); } }
+    }
+
+    private int _planCount;
+    public int PlanCount
+    {
+        get => _planCount;
+        set { if (_planCount != value) { _planCount = value; OnPropertyChanged(); } }
+    }
+
+    private bool _isLoading;
+    public bool IsLoading
+    {
+        get => _isLoading;
+        set { if (_isLoading != value) { _isLoading = value; OnPropertyChanged(); } }
+    }
+
+    public HomeViewModel(IRecipeService recipeService, IPlanService planService)
+    {
+        _recipeService = recipeService;
+        _planService = planService;
+    }
+
+    public async Task LoadAsync()
+    {
+        if (IsLoading) return;
+        IsLoading = true;
+
+        var recipes = await _recipeService.GetRecipesAsync();
+        RecipeCount = recipes.Count;
+
+        var plans = await _planService.GetPlansAsync();
+        PlanCount = plans.Count;
+
+        IsLoading = false;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? name = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+}
+

--- a/ViewModels/PlannerViewModel.cs
+++ b/ViewModels/PlannerViewModel.cs
@@ -72,7 +72,12 @@ public class PlannerViewModel : INotifyPropertyChanged
 
         AddMealCommand = new Command<PlannerDay>(AddMeal);
         RemoveMealCommand = new Command<PlannedMeal>(RemoveMeal);
-        SaveCommand = new Command(async () => await SaveAsync());
+        SaveCommand = new Command(async () =>
+        {
+            var plan = await SaveAsync();
+            if (plan != null)
+                await Shell.Current.GoToAsync($"//{nameof(Foodbook.Views.ShoppingListPage)}");
+        });
         CancelCommand = new Command(async () => await Shell.Current.GoToAsync(".."));
     }
 

--- a/Views/HomePage.xaml
+++ b/Views/HomePage.xaml
@@ -1,11 +1,20 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Foodbook.ViewModels"
+             xmlns:converters="clr-namespace:Foodbook.Converters"
              x:Class="Foodbook.Views.HomePage"
-             Title="Home">
-    <StackLayout>
-        <Label Text="Welcome to Foodbook!" 
-               VerticalOptions="CenterAndExpand" 
-               HorizontalOptions="Center" />
+             x:DataType="vm:HomeViewModel"
+             Title="Start">
+    <ContentPage.Resources>
+        <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+    </ContentPage.Resources>
+    <StackLayout Padding="20" Spacing="10">
+        <Label Text="Witaj w Foodbook" FontAttributes="Bold" FontSize="20" HorizontalOptions="Center" />
+        <ActivityIndicator IsVisible="{Binding IsLoading}" IsRunning="{Binding IsLoading}" />
+        <StackLayout IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" Spacing="6">
+            <Label Text="Liczba przepisów: {Binding RecipeCount}" />
+            <Label Text="Zaplanowane foodbooki: {Binding PlanCount}" />
+        </StackLayout>
     </StackLayout>
 </ContentPage>

--- a/Views/HomePage.xaml.cs
+++ b/Views/HomePage.xaml.cs
@@ -1,0 +1,22 @@
+using Foodbook.ViewModels;
+
+namespace Foodbook.Views;
+
+public partial class HomePage : ContentPage
+{
+    private HomeViewModel ViewModel => BindingContext as HomeViewModel;
+
+    public HomePage(HomeViewModel vm)
+    {
+        InitializeComponent();
+        BindingContext = vm;
+    }
+
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        if (ViewModel != null)
+            await ViewModel.LoadAsync();
+    }
+}
+

--- a/Views/PlannerPage.xaml
+++ b/Views/PlannerPage.xaml
@@ -6,11 +6,11 @@
              x:Class="Foodbook.Views.PlannerPage"
              x:Name="ThisPage"
              x:DataType="vm:PlannerViewModel"
-             Title="Planner">
+             Title="Planer">
     <ScrollView>
         <VerticalStackLayout Padding="10" Spacing="10">
             <HorizontalStackLayout>
-                <Label Text="Start:" VerticalOptions="Center" />
+                <Label Text="Początek:" VerticalOptions="Center" />
                 <DatePicker Date="{Binding StartDate}" />
                 <Label Text="Koniec:" VerticalOptions="Center" />
                 <DatePicker Date="{Binding EndDate}" />
@@ -28,9 +28,10 @@
                                 <StackLayout BindableLayout.ItemsSource="{Binding Meals}">
                                     <BindableLayout.ItemTemplate>
                                         <DataTemplate x:DataType="models:PlannedMeal">
-                                            <Grid ColumnDefinitions="0.85*,Auto" ColumnSpacing="5">
+                                            <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="5">
                                                 <Picker Grid.Column="0" ItemsSource="{Binding Source={x:Reference ThisPage}, Path=BindingContext.Recipes}" ItemDisplayBinding="{Binding Name}" SelectedItem="{Binding Recipe}" />
-                                                <Button Grid.Column="1" Text="✖" Command="{Binding BindingContext.RemoveMealCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" WidthRequest="30" />
+                                                <Stepper Grid.Column="1" Minimum="1" Maximum="20" Increment="1" Value="{Binding Portions}" WidthRequest="100" />
+                                                <Button Grid.Column="2" Text="✖" Command="{Binding BindingContext.RemoveMealCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" WidthRequest="25" />
                                             </Grid>
                                         </DataTemplate>
                                     </BindableLayout.ItemTemplate>

--- a/Views/ShoppingListDetailPage.xaml
+++ b/Views/ShoppingListDetailPage.xaml
@@ -3,19 +3,38 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
+             xmlns:converters="clr-namespace:Foodbook.Converters"
              x:Class="Foodbook.Views.ShoppingListDetailPage"
              x:Name="ThisPage"
              x:DataType="vm:ShoppingListDetailViewModel"
              Title="Shopping List">
+    <ContentPage.Resources>
+        <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+    </ContentPage.Resources>
     <StackLayout Padding="10" Spacing="10">
         <CollectionView ItemsSource="{Binding Items}">
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="models:Ingredient">
-                    <Grid ColumnDefinitions="2*,Auto,Auto,Auto" Padding="5" ColumnSpacing="5">
-                        <Entry Text="{Binding Name}" Placeholder="Nazwa" Grid.Column="0" />
-                        <Entry Text="{Binding Quantity}" Keyboard="Numeric" WidthRequest="60" Grid.Column="1" />
-                        <Picker Grid.Column="2" WidthRequest="80" ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}" SelectedItem="{Binding Unit}" />
-                        <Button Grid.Column="3" Text="Usuń" Command="{Binding BindingContext.RemoveItemCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
+                    <Grid ColumnDefinitions="Auto,2*,Auto,Auto,Auto" Padding="5" ColumnSpacing="5">
+                        <CheckBox Grid.Column="0" IsChecked="{Binding IsChecked}" />
+
+                        <Entry Grid.Column="1" Text="{Binding Name}" Placeholder="Nazwa"
+                               IsVisible="{Binding IsChecked, Converter={StaticResource InvertedBoolConverter}}" />
+                        <Label Grid.Column="1" Text="{Binding Name}" TextDecorations="Strikethrough" TextColor="Gray"
+                               VerticalTextAlignment="Center"
+                               IsVisible="{Binding IsChecked}" />
+
+                        <Entry Grid.Column="2" Text="{Binding Quantity}" Keyboard="Numeric" WidthRequest="60"
+                               IsVisible="{Binding IsChecked, Converter={StaticResource InvertedBoolConverter}}" />
+                        <Label Grid.Column="2" Text="{Binding Quantity}" TextDecorations="Strikethrough" TextColor="Gray" VerticalTextAlignment="Center"
+                               IsVisible="{Binding IsChecked}" />
+
+                        <Picker Grid.Column="3" WidthRequest="80" ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}" SelectedItem="{Binding Unit}"
+                                IsVisible="{Binding IsChecked, Converter={StaticResource InvertedBoolConverter}}" />
+                        <Label Grid.Column="3" Text="{Binding Unit}" TextDecorations="Strikethrough" TextColor="Gray" VerticalTextAlignment="Center"
+                               IsVisible="{Binding IsChecked}" />
+
+                        <Button Grid.Column="4" Text="Usuń" Command="{Binding BindingContext.RemoveItemCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
                     </Grid>
                 </DataTemplate>
             </CollectionView.ItemTemplate>

--- a/Views/ShoppingListPage.xaml
+++ b/Views/ShoppingListPage.xaml
@@ -6,15 +6,17 @@
              x:Class="Foodbook.Views.ShoppingListPage"
              x:Name="ThisPage"
              x:DataType="vm:ShoppingListViewModel"
-             Title="Shopping Lists">
+             Title="Listy zakupów">
     <CollectionView ItemsSource="{Binding Plans}" Margin="10" SelectionMode="None">
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="models:Plan">
-                <Grid ColumnDefinitions="*,Auto,Auto" Padding="5">
-                    <Label Text="{Binding Label}" Grid.Column="0" />
-                    <Button Grid.Column="1" Text="Edit" Command="{Binding BindingContext.OpenPlanCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
-                    <Button Grid.Column="2" Text="Delete" Command="{Binding BindingContext.DeletePlanCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" />
-                </Grid>
+                <Border Stroke="LightGray" StrokeThickness="1" Padding="8" Margin="0,5">
+                    <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="10">
+                        <Label Text="{Binding Label}" Grid.Column="0" VerticalOptions="Center" />
+                        <Button Grid.Column="1" Text="✎" Command="{Binding BindingContext.OpenPlanCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" WidthRequest="40" />
+                        <Button Grid.Column="2" Text="🗑" Command="{Binding BindingContext.DeletePlanCommand, Source={x:Reference ThisPage}}" CommandParameter="{Binding .}" WidthRequest="40" />
+                    </Grid>
+                </Border>
             </DataTemplate>
         </CollectionView.ItemTemplate>
     </CollectionView>


### PR DESCRIPTION
## Summary
- add `IsChecked` flag to `Ingredient`
- checkbox and strike-through behavior in shopping list detail
- border and icons for shopping list list items
- spinner for portions in planner
- navigate to shopping list after saving plan
- add Home screen with recipe/plan counts
- polish translation updates

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68603d97fba08330a73323256ff3f4f9