### PR TITLE
Set neutral language to English

### DIFF
--- a/FoodbookApp.csproj
+++ b/FoodbookApp.csproj
@@ -39,7 +39,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-		<NeutralLanguage>pl</NeutralLanguage>
+                <NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>
 
 	<ItemGroup>
@@ -199,7 +199,9 @@
             <LastGenOutput>SettingsPageResources.Designer.cs</LastGenOutput>
           </EmbeddedResource>
         </ItemGroup>
-
+  <ItemGroup>
+    <EmbeddedResource Include="Localization\*.pl-PL.resx" />
+  </ItemGroup>
 	<ItemGroup>
 	  <MauiXaml Update="Views\AddRecipePage.xaml">
 	    <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
## Summary
- switch neutral language to English
- include Polish .resx files as embedded resources for satellite assemblies

## Testing
- `dotnet build FoodbookApp.sln -v minimal --no-restore` *(fails: workloads not installed)*

------
https://chatgpt.com/codex/tasks/task_b_687d33b58aa08330b9beffdca6064ef1