### PR TITLE
Replace Polish UI text with resources

### DIFF
--- a/Localization/HomePageResources.Designer.cs
+++ b/Localization/HomePageResources.Designer.cs
@@ -165,6 +165,12 @@ namespace FoodbookApp.Localization {
             }
         }
 
+        internal static string GoToSettings {
+            get {
+                return ResourceManager.GetString("GoToSettings", resourceCulture);
+            }
+        }
+
         internal static string ComingSoon {
             get {
                 return ResourceManager.GetString("ComingSoon", resourceCulture);

--- a/Localization/HomePageResources.pl-PL.resx
+++ b/Localization/HomePageResources.pl-PL.resx
@@ -72,6 +72,9 @@
   <data name="Customize" xml:space="preserve">
     <value>Personalizuj</value>
   </data>
+  <data name="GoToSettings" xml:space="preserve">
+    <value>Przejdź do ustawień</value>
+  </data>
   <data name="ComingSoon" xml:space="preserve">
     <value>Wkrótce</value>
   </data>

--- a/Localization/HomePageResources.resx
+++ b/Localization/HomePageResources.resx
@@ -72,6 +72,9 @@
   <data name="Customize" xml:space="preserve">
     <value>Customize</value>
   </data>
+  <data name="GoToSettings" xml:space="preserve">
+    <value>Go to settings</value>
+  </data>
   <data name="ComingSoon" xml:space="preserve">
     <value>Soon</value>
   </data>

--- a/Localization/IngredientFormPageResources.Designer.cs
+++ b/Localization/IngredientFormPageResources.Designer.cs
@@ -93,6 +93,24 @@ namespace FoodbookApp.Localization {
             }
         }
 
+        internal static string ProteinLabel {
+            get {
+                return ResourceManager.GetString("ProteinLabel", resourceCulture);
+            }
+        }
+
+        internal static string FatLabel {
+            get {
+                return ResourceManager.GetString("FatLabel", resourceCulture);
+            }
+        }
+
+        internal static string CarbsLabel {
+            get {
+                return ResourceManager.GetString("CarbsLabel", resourceCulture);
+            }
+        }
+
         internal static string VerifyLabel {
             get {
                 return ResourceManager.GetString("VerifyLabel", resourceCulture);

--- a/Localization/IngredientFormPageResources.pl-PL.resx
+++ b/Localization/IngredientFormPageResources.pl-PL.resx
@@ -36,6 +36,15 @@
   <data name="NutritionHeader" xml:space="preserve">
     <value>Wartości odżywcze</value>
   </data>
+  <data name="ProteinLabel" xml:space="preserve">
+    <value>Białko (g)</value>
+  </data>
+  <data name="FatLabel" xml:space="preserve">
+    <value>Tłuszcze (g)</value>
+  </data>
+  <data name="CarbsLabel" xml:space="preserve">
+    <value>Węglowodany (g)</value>
+  </data>
   <data name="VerifyLabel" xml:space="preserve">
     <value>Zweryfikuj dane z OpenFoodFacts:</value>
   </data>

--- a/Localization/IngredientFormPageResources.resx
+++ b/Localization/IngredientFormPageResources.resx
@@ -36,6 +36,15 @@
   <data name="NutritionHeader" xml:space="preserve">
     <value>Nutrition values</value>
   </data>
+  <data name="ProteinLabel" xml:space="preserve">
+    <value>Protein (g)</value>
+  </data>
+  <data name="FatLabel" xml:space="preserve">
+    <value>Fats (g)</value>
+  </data>
+  <data name="CarbsLabel" xml:space="preserve">
+    <value>Carbs (g)</value>
+  </data>
   <data name="VerifyLabel" xml:space="preserve">
     <value>Verify with OpenFoodFacts:</value>
   </data>

--- a/Localization/IngredientsPageResources.Designer.cs
+++ b/Localization/IngredientsPageResources.Designer.cs
@@ -74,5 +74,47 @@ namespace FoodbookApp.Localization {
                 return ResourceManager.GetString("EmptyHint", resourceCulture);
             }
         }
+
+        internal static string EmptyDialogTitle {
+            get {
+                return ResourceManager.GetString("EmptyDialogTitle", resourceCulture);
+            }
+        }
+
+        internal static string EmptyDialogMessage {
+            get {
+                return ResourceManager.GetString("EmptyDialogMessage", resourceCulture);
+            }
+        }
+
+        internal static string EmptyDialogConfirm {
+            get {
+                return ResourceManager.GetString("EmptyDialogConfirm", resourceCulture);
+            }
+        }
+
+        internal static string EmptyDialogCancel {
+            get {
+                return ResourceManager.GetString("EmptyDialogCancel", resourceCulture);
+            }
+        }
+
+        internal static string LoadErrorTitle {
+            get {
+                return ResourceManager.GetString("LoadErrorTitle", resourceCulture);
+            }
+        }
+
+        internal static string LoadErrorMessage {
+            get {
+                return ResourceManager.GetString("LoadErrorMessage", resourceCulture);
+            }
+        }
+
+        internal static string Ok {
+            get {
+                return ResourceManager.GetString("Ok", resourceCulture);
+            }
+        }
     }
 }

--- a/Localization/IngredientsPageResources.pl-PL.resx
+++ b/Localization/IngredientsPageResources.pl-PL.resx
@@ -27,4 +27,25 @@
   <data name="EmptyHint" xml:space="preserve">
     <value>Dotknij 'Dodaj składnik' aby dodać pierwszy składnik</value>
   </data>
+  <data name="EmptyDialogTitle" xml:space="preserve">
+    <value>Brak składników</value>
+  </data>
+  <data name="EmptyDialogMessage" xml:space="preserve">
+    <value>Utworzyć listę przykładowych składników?</value>
+  </data>
+  <data name="EmptyDialogConfirm" xml:space="preserve">
+    <value>Tak</value>
+  </data>
+  <data name="EmptyDialogCancel" xml:space="preserve">
+    <value>Nie</value>
+  </data>
+  <data name="LoadErrorTitle" xml:space="preserve">
+    <value>Błąd</value>
+  </data>
+  <data name="LoadErrorMessage" xml:space="preserve">
+    <value>Wystąpił problem podczas ładowania składników.</value>
+  </data>
+  <data name="Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
 </root>

--- a/Localization/IngredientsPageResources.resx
+++ b/Localization/IngredientsPageResources.resx
@@ -27,4 +27,25 @@
   <data name="EmptyHint" xml:space="preserve">
     <value>Tap 'Add ingredient' to create one</value>
   </data>
+  <data name="EmptyDialogTitle" xml:space="preserve">
+    <value>No ingredients</value>
+  </data>
+  <data name="EmptyDialogMessage" xml:space="preserve">
+    <value>Create sample ingredients list?</value>
+  </data>
+  <data name="EmptyDialogConfirm" xml:space="preserve">
+    <value>Yes</value>
+  </data>
+  <data name="EmptyDialogCancel" xml:space="preserve">
+    <value>No</value>
+  </data>
+  <data name="LoadErrorTitle" xml:space="preserve">
+    <value>Error</value>
+  </data>
+  <data name="LoadErrorMessage" xml:space="preserve">
+    <value>An error occurred while loading ingredients.</value>
+  </data>
+  <data name="Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
 </root>

--- a/Views/HomePage.xaml
+++ b/Views/HomePage.xaml
@@ -391,7 +391,7 @@
                                Margin="0,16,0,8" />
                         <Button Style="{StaticResource CardButtonStyle}"
                                 BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                                Text="Przejdź do ustawień"
+                                Text="{x:Static resources:HomePageResources.GoToSettings}"
                                 Clicked="OnSettingsClicked" />
                     </StackLayout>
                 </Frame>

--- a/Views/IngredientFormPage.xaml
+++ b/Views/IngredientFormPage.xaml
@@ -104,7 +104,7 @@
                 
                 <!-- Protein Field -->
                 <StackLayout Grid.Row="0" Grid.Column="1" Spacing="5">
-                    <Label Text="Białko (g)" FontAttributes="Bold" />
+                    <Label Text="{x:Static resources:IngredientFormPageResources.ProteinLabel}" FontAttributes="Bold" />
                     <Entry Placeholder="0.0" 
                            Keyboard="Numeric" 
                            Text="{Binding Protein}"
@@ -114,7 +114,7 @@
                 
                 <!-- Fat Field -->
                 <StackLayout Grid.Row="1" Grid.Column="0" Spacing="5">
-                    <Label Text="Tłuszcze (g)" FontAttributes="Bold" />
+                    <Label Text="{x:Static resources:IngredientFormPageResources.FatLabel}" FontAttributes="Bold" />
                     <Entry Placeholder="0.0" 
                            Keyboard="Numeric" 
                            Text="{Binding Fat}"
@@ -124,7 +124,7 @@
                 
                 <!-- Carbs Field -->
                 <StackLayout Grid.Row="1" Grid.Column="1" Spacing="5">
-                    <Label Text="Węglowodany (g)" FontAttributes="Bold" />
+                    <Label Text="{x:Static resources:IngredientFormPageResources.CarbsLabel}" FontAttributes="Bold" />
                     <Entry Placeholder="0.0" 
                            Keyboard="Numeric" 
                            Text="{Binding Carbs}"

--- a/Views/IngredientsPage.xaml.cs
+++ b/Views/IngredientsPage.xaml.cs
@@ -3,6 +3,7 @@ using Foodbook.ViewModels;
 using Foodbook.Data;
 using Microsoft.Extensions.DependencyInjection;
 using FoodbookApp;
+using FoodbookApp.Localization;
 
 namespace Foodbook.Views;
 
@@ -46,8 +47,10 @@ public partial class IngredientsPage : ContentPage
     {
         try
         {
-            bool create = await DisplayAlert("Brak składników", 
-                "Utworzyć listę przykładowych składników?", "Tak", "Nie");
+            bool create = await DisplayAlert(IngredientsPageResources.EmptyDialogTitle,
+                IngredientsPageResources.EmptyDialogMessage,
+                IngredientsPageResources.EmptyDialogConfirm,
+                IngredientsPageResources.EmptyDialogCancel);
             
             if (create && MauiProgram.ServiceProvider != null)
             {
@@ -62,7 +65,9 @@ public partial class IngredientsPage : ContentPage
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Error handling empty ingredients: {ex.Message}");
-            await DisplayAlert("Błąd", "Wystąpił problem podczas ładowania składników.", "OK");
+            await DisplayAlert(IngredientsPageResources.LoadErrorTitle,
+                IngredientsPageResources.LoadErrorMessage,
+                IngredientsPageResources.Ok);
         }
     }
 }


### PR DESCRIPTION
## Summary
- add GoToSettings button text to HomePage resources
- add nutrition labels to IngredientForm resources
- add dialog strings to IngredientsPage resources
- update XAML and C# files to use resource strings

## Testing
- `dotnet workload restore`
- `dotnet build FoodbookApp.sln -c Release` *(fails: missing iOS workload)*

------
https://chatgpt.com/codex/tasks/task_b_687d35437ae08330b893240fff61ea44