### PR TITLE
Implement runtime localization

### DIFF
--- a/AppShell.xaml
+++ b/AppShell.xaml
@@ -3,29 +3,30 @@
     x:Class="FoodbookApp.AppShell"
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:services="clr-namespace:Foodbook.Services"
     xmlns:views="clr-namespace:Foodbook.Views"
     xmlns:tabbar="clr-namespace:FoodbookApp.Localization"
     Title="FoodbookApp">
 
     <TabBar>
         <ShellContent
-            Title="{x:Static tabbar:TabBarResources.Ingredients}"
+            Title="{services:Translate BaseName=TabBarResources, Key=Ingredients}"
             Icon="grocery.png"
             ContentTemplate="{DataTemplate views:IngredientsPage}" />
         <ShellContent
-            Title="{x:Static tabbar:TabBarResources.Recipes}"
+            Title="{services:Translate BaseName=TabBarResources, Key=Recipes}"
             Icon="chef_hat.png"
             ContentTemplate="{DataTemplate views:RecipesPage}" />
         <ShellContent
-            Title="{x:Static tabbar:TabBarResources.Home}"
+            Title="{services:Translate BaseName=TabBarResources, Key=Home}"
             Icon="home.png"
             ContentTemplate="{DataTemplate views:HomePage}" />
         <ShellContent
-            Title="{x:Static tabbar:TabBarResources.Planner}"
+            Title="{services:Translate BaseName=TabBarResources, Key=Planner}"
             Icon="event_upcoming.png"
             ContentTemplate="{DataTemplate views:PlannerPage}" />
         <ShellContent
-            Title="{x:Static tabbar:TabBarResources.ShoppingLists}"
+            Title="{services:Translate BaseName=TabBarResources, Key=ShoppingLists}"
             Icon="event_list.png"
             ContentTemplate="{DataTemplate views:ShoppingListPage}" />
     </TabBar>

--- a/FoodbookApp.csproj
+++ b/FoodbookApp.csproj
@@ -39,7 +39,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-		<NeutralLanguage>pl</NeutralLanguage>
+                <NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -42,6 +42,7 @@ namespace FoodbookApp
             builder.Services.AddScoped<IPlanService, PlanService>();
             builder.Services.AddScoped<IIngredientService, IngredientService>();
             builder.Services.AddSingleton<ILocalizationService, LocalizationService>();
+            builder.Services.AddSingleton<LocalizationResourceManager>();
 
             builder.Services.AddScoped<RecipeViewModel>();
             builder.Services.AddTransient<AddRecipeViewModel>(); // Zmieniono na Transient
@@ -53,6 +54,7 @@ namespace FoodbookApp
             builder.Services.AddScoped<IngredientFormViewModel>();
             builder.Services.AddScoped<PlannedMealFormViewModel>();
             builder.Services.AddScoped<ArchiveViewModel>(); // Dodany ArchiveViewModel
+            builder.Services.AddScoped<SettingsViewModel>();
 
             // Rejestracja HttpClient i RecipeImporter
             builder.Services.AddScoped<HttpClient>();

--- a/Services/ILocalizationService.cs
+++ b/Services/ILocalizationService.cs
@@ -5,6 +5,7 @@ namespace Foodbook.Services;
 public interface ILocalizationService
 {
     CultureInfo CurrentCulture { get; }
+    event EventHandler? CultureChanged;
     void SetCulture(string cultureName);
     string GetString(string baseName, string key);
 }

--- a/Services/LocalizationResourceManager.cs
+++ b/Services/LocalizationResourceManager.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Foodbook.Services;
+
+public class LocalizationResourceManager : INotifyPropertyChanged
+{
+    private readonly ILocalizationService _localizationService;
+
+    public LocalizationResourceManager(ILocalizationService localizationService)
+    {
+        _localizationService = localizationService;
+        _localizationService.CultureChanged += (_, __) => OnPropertyChanged(null);
+    }
+
+    public string this[string key]
+    {
+        get
+        {
+            var parts = key.Split('.');
+            if (parts.Length == 2)
+            {
+                return _localizationService.GetString(parts[0], parts[1]);
+            }
+            return key;
+        }
+    }
+
+    public static LocalizationResourceManager Instance =>
+        MauiProgram.ServiceProvider!.GetRequiredService<LocalizationResourceManager>();
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged(string? propertyName) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -9,6 +9,8 @@ public class LocalizationService : ILocalizationService
 {
     private readonly Dictionary<string, ResourceManager> _resourceManagers = new();
 
+    public event EventHandler? CultureChanged;
+
     public CultureInfo CurrentCulture { get; private set; } = CultureInfo.CurrentUICulture;
 
     public void SetCulture(string cultureName)
@@ -32,6 +34,8 @@ public class LocalizationService : ILocalizationService
         ShoppingListDetailPageResources.Culture = culture;
         ShoppingListPageResources.Culture = culture;
         TabBarResources.Culture = culture;
+
+        CultureChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public string GetString(string baseName, string key)

--- a/Services/TranslateExtension.cs
+++ b/Services/TranslateExtension.cs
@@ -1,0 +1,19 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Controls.Xaml;
+
+namespace Foodbook.Services;
+
+[ContentProperty(nameof(Key))]
+public class TranslateExtension : IMarkupExtension<BindingBase>
+{
+    public string BaseName { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+
+    public BindingBase ProvideValue(IServiceProvider serviceProvider)
+    {
+        return new Binding($"[{BaseName}.{Key}]", source: LocalizationResourceManager.Instance);
+    }
+
+    object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
+        => ProvideValue(serviceProvider);
+}

--- a/ViewModels/SettingsViewModel.cs
+++ b/ViewModels/SettingsViewModel.cs
@@ -1,0 +1,43 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Foodbook.Services;
+
+namespace Foodbook.ViewModels;
+
+public class SettingsViewModel : INotifyPropertyChanged
+{
+    private readonly ILocalizationService _localizationService;
+
+    public ObservableCollection<CultureInfo> AvailableCultures { get; } = new()
+    {
+        new CultureInfo("en"),
+        new CultureInfo("pl-PL")
+    };
+
+    private CultureInfo _selectedCulture;
+    public CultureInfo SelectedCulture
+    {
+        get => _selectedCulture;
+        set
+        {
+            if (_selectedCulture != value)
+            {
+                _selectedCulture = value;
+                OnPropertyChanged();
+                _localizationService.SetCulture(value.Name);
+            }
+        }
+    }
+
+    public SettingsViewModel(ILocalizationService localizationService)
+    {
+        _localizationService = localizationService;
+        _selectedCulture = localizationService.CurrentCulture;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}

--- a/Views/AddRecipePage.xaml
+++ b/Views/AddRecipePage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
             xmlns:converters="clr-namespace:Foodbook.Converters"
@@ -27,7 +28,7 @@
 
             <!-- Mode Selection Section -->
             <StackLayout Spacing="10">
-                <Label Text="{x:Static resources:AddRecipePageResources.ModeSelection}"
+                <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=ModeSelection}"
                        FontSize="18"
                        FontAttributes="Bold" />
                 
@@ -37,26 +38,26 @@
                             BackgroundColor="{Binding IsManualMode, Converter={StaticResource BoolToColorConverter}}"
                             TextColor="White"
                             HeightRequest="45"
-                            Text="{x:Static resources:AddRecipePageResources.Manual}"/>
+                            Text="{services:Translate BaseName=AddRecipePageResources, Key=Manual}"/>
                     <Button Grid.Column="1"
                             Command="{Binding SetImportModeCommand}"
                             BackgroundColor="{Binding IsImportMode, Converter={StaticResource BoolToColorConverter}}"
                             TextColor="White"
                             HeightRequest="45"
-                            Text="{x:Static resources:AddRecipePageResources.FromLink}"/>
+                            Text="{services:Translate BaseName=AddRecipePageResources, Key=FromLink}"/>
                 </Grid>
             </StackLayout>
 
             <!-- Import Section -->
             <StackLayout IsVisible="{Binding IsImportMode}" Spacing="10">
-                <Label Text="{x:Static resources:AddRecipePageResources.ImportHeader}"
+                <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=ImportHeader}"
                        FontSize="18"
                        FontAttributes="Bold"
                        Margin="0,10,0,5" />
                 
                 <StackLayout Spacing="5">
-                    <Label Text="{x:Static resources:AddRecipePageResources.UrlLabel}" FontAttributes="Bold" />
-                    <Entry Placeholder="{x:Static resources:AddRecipePageResources.UrlPlaceholder}"
+                    <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=UrlLabel}" FontAttributes="Bold" />
+                    <Entry Placeholder="{services:Translate BaseName=AddRecipePageResources, Key=UrlPlaceholder}"
                            Text="{Binding ImportUrl}"
                            ClearButtonVisibility="WhileEditing"
                            Keyboard="Url" />
@@ -64,7 +65,7 @@
                 
                 <Button Command="{Binding ImportRecipeCommand}"
                         HeightRequest="45"
-                        Text="{x:Static resources:AddRecipePageResources.ImportButton}"/>
+                        Text="{services:Translate BaseName=AddRecipePageResources, Key=ImportButton}"/>
                 
                 <Label Text="{Binding ImportStatus}" 
                        FontSize="12" 
@@ -76,29 +77,29 @@
             <StackLayout IsVisible="{Binding IsManualMode}" Spacing="10">
                 
                 <!-- Basic Information -->
-                <Label Text="{x:Static resources:AddRecipePageResources.BasicInfoHeader}"
+                <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=BasicInfoHeader}"
 
                        FontSize="18" 
                        FontAttributes="Bold" 
                        Margin="0,10,0,5" />
                 
                 <StackLayout Spacing="5">
-                    <Label Text="{x:Static resources:AddRecipePageResources.NameLabel}" FontAttributes="Bold" />
-                    <Entry Placeholder="{x:Static resources:AddRecipePageResources.NamePlaceholder}"
+                    <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=NameLabel}" FontAttributes="Bold" />
+                    <Entry Placeholder="{services:Translate BaseName=AddRecipePageResources, Key=NamePlaceholder}"
                            Text="{Binding Name}" 
                            ClearButtonVisibility="WhileEditing" />
                 </StackLayout>
                 
                 <StackLayout Spacing="5">
-                    <Label Text="{x:Static resources:AddRecipePageResources.DescriptionLabel}" FontAttributes="Bold" />
-                    <Editor Placeholder="{x:Static resources:AddRecipePageResources.DescriptionPlaceholder}"
+                    <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=DescriptionLabel}" FontAttributes="Bold" />
+                    <Editor Placeholder="{services:Translate BaseName=AddRecipePageResources, Key=DescriptionPlaceholder}"
                             Text="{Binding Description}" 
                             AutoSize="TextChanges"
                             HeightRequest="80" />
                 </StackLayout>
 
                 <StackLayout Spacing="5">
-                    <Label Text="{x:Static resources:AddRecipePageResources.PortionsLabel}" FontAttributes="Bold" />
+                    <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=PortionsLabel}" FontAttributes="Bold" />
                     <Entry Placeholder="2" 
                            Keyboard="Numeric"
                            Text="{Binding IloscPorcji}" 
@@ -109,7 +110,7 @@
                 </StackLayout>
 
                 <!-- Ingredients Section - MOVED UP -->
-                <Label Text="{x:Static resources:AddRecipePageResources.IngredientsHeader}"
+                <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=IngredientsHeader}"
                        FontSize="18" 
                        FontAttributes="Bold" 
                        Margin="0,15,0,5" />
@@ -129,8 +130,8 @@
                                     
                                     <!-- Nazwa składnika -->
                                     <StackLayout Grid.Row="0" Grid.Column="0" Spacing="3">
-                                        <Label Text="{x:Static resources:AddRecipePageResources.IngredientLabel}" FontSize="12" FontAttributes="Bold" />
-                                        <Picker Title="{x:Static resources:AddRecipePageResources.ChooseIngredient}"
+                                        <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=IngredientLabel}" FontSize="12" FontAttributes="Bold" />
+                                        <Picker Title="{services:Translate BaseName=AddRecipePageResources, Key=ChooseIngredient}"
                                                 ItemsSource="{Binding BindingContext.AvailableIngredientNames, Source={x:Reference ThisPage}}"
                                                 SelectedItem="{Binding Name}"
                                                 SelectedIndexChanged="OnIngredientNameChanged" />
@@ -138,7 +139,7 @@
                                     
                                     <!-- Ilość -->
                                     <StackLayout Grid.Row="0" Grid.Column="1" Spacing="3">
-                                        <Label Text="{x:Static resources:AddRecipePageResources.QuantityLabelShort}" FontSize="12" FontAttributes="Bold" />
+                                        <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=QuantityLabelShort}" FontSize="12" FontAttributes="Bold" />
                                         <Entry Placeholder="1.0"
                                                Keyboard="Numeric"
                                                Text="{Binding Quantity}"
@@ -148,8 +149,8 @@
                                     
                                     <!-- Jednostka -->
                                     <StackLayout Grid.Row="0" Grid.Column="2" Spacing="3">
-                                        <Label Text="{x:Static resources:AddRecipePageResources.UnitLabelShort}" FontSize="12" FontAttributes="Bold" />
-                                        <Picker Title="{x:Static resources:AddRecipePageResources.UnitLabelShort}"
+                                        <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=UnitLabelShort}" FontSize="12" FontAttributes="Bold" />
+                                        <Picker Title="{services:Translate BaseName=AddRecipePageResources, Key=UnitLabelShort}"
                                                 ItemsSource="{Binding BindingContext.Units, Source={x:Reference ThisPage}}"
                                                 SelectedItem="{Binding Unit}"
                                                 SelectedIndexChanged="OnIngredientValueChanged"
@@ -195,17 +196,17 @@
                 
                 <Button Command="{Binding AddIngredientCommand}"
                         HeightRequest="45"
-                        Text="{x:Static resources:AddRecipePageResources.AddIngredient}"/>
+                        Text="{services:Translate BaseName=AddRecipePageResources, Key=AddIngredient}"/>
 
                 <!-- Nutritional Information - MOVED DOWN -->
-                <Label Text="{x:Static resources:AddRecipePageResources.NutritionHeader}"
+                <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=NutritionHeader}"
                        FontSize="18"
                        FontAttributes="Bold"
                        Margin="0,20,0,5" />
 
                 <!-- Calculation Mode Toggle -->
                 <StackLayout Spacing="10">
-                    <Label Text="{x:Static resources:AddRecipePageResources.CalcModeLabel}"
+                    <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=CalcModeLabel}"
                            FontSize="14"
                            FontAttributes="Bold" />
                     
@@ -215,26 +216,26 @@
                                 TextColor="White"
                                 HeightRequest="40"
                                 Clicked="OnAutoModeClicked"
-                                Text="{x:Static resources:AddRecipePageResources.AutoButton}"/>
+                                Text="{services:Translate BaseName=AddRecipePageResources, Key=AutoButton}"/>
                         <Button Grid.Column="1"
                                 BackgroundColor="{Binding UseManualValues, Converter={StaticResource BoolToColorConverter}}"
                                 TextColor="White"
                                 HeightRequest="40"
                                 Clicked="OnManualModeClicked"
-                                Text="{x:Static resources:AddRecipePageResources.ManualButton}"/>
+                                Text="{services:Translate BaseName=AddRecipePageResources, Key=ManualButton}"/>
                     </Grid>
                 </StackLayout>
 
                 <!-- Calculated Values Display -->
                 <StackLayout IsVisible="{Binding UseCalculatedValues}" Spacing="10">
-                    <Label Text="{x:Static resources:AddRecipePageResources.AutoCalculatedInfo}"
+                    <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=AutoCalculatedInfo}"
                            FontSize="12"
                            FontAttributes="Italic"
                            HorizontalTextAlignment="Center" />
                     
                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10" RowDefinitions="Auto,Auto" RowSpacing="10">
                         <StackLayout Grid.Row="0" Grid.Column="0" Spacing="5">
-                            <Label Text="{x:Static resources:AddRecipePageResources.CaloriesLabel}" FontAttributes="Bold" />
+                            <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=CaloriesLabel}" FontAttributes="Bold" />
                             <Label Text="{Binding CalculatedCalories}" 
                                    FontSize="16"
                                    HorizontalTextAlignment="Center"
@@ -244,7 +245,7 @@
                         </StackLayout>
                         
                         <StackLayout Grid.Row="0" Grid.Column="1" Spacing="5">
-                            <Label Text="{x:Static resources:AddRecipePageResources.ProteinLabel}" FontAttributes="Bold" />
+                            <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=ProteinLabel}" FontAttributes="Bold" />
                             <Label Text="{Binding CalculatedProtein}" 
                                    FontSize="16"
                                    HorizontalTextAlignment="Center"
@@ -254,7 +255,7 @@
                         </StackLayout>
                         
                         <StackLayout Grid.Row="1" Grid.Column="0" Spacing="5">
-                            <Label Text="{x:Static resources:AddRecipePageResources.FatLabel}" FontAttributes="Bold" />
+                            <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=FatLabel}" FontAttributes="Bold" />
                             <Label Text="{Binding CalculatedFat}" 
                                    FontSize="16"
                                    HorizontalTextAlignment="Center"
@@ -264,7 +265,7 @@
                         </StackLayout>
                         
                         <StackLayout Grid.Row="1" Grid.Column="1" Spacing="5">
-                            <Label Text="{x:Static resources:AddRecipePageResources.CarbsLabel}" FontAttributes="Bold" />
+                            <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=CarbsLabel}" FontAttributes="Bold" />
                             <Label Text="{Binding CalculatedCarbs}" 
                                    FontSize="16"
                                    HorizontalTextAlignment="Center"
@@ -279,7 +280,7 @@
                 <StackLayout IsVisible="{Binding UseManualValues}" Spacing="10">
                     <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                         <Label Grid.Column="0"
-                               Text="{x:Static resources:AddRecipePageResources.ManualInputLabel}"
+                               Text="{services:Translate BaseName=AddRecipePageResources, Key=ManualInputLabel}"
                                FontSize="12"
                                FontAttributes="Italic"
                                VerticalOptions="Center" />
@@ -287,12 +288,12 @@
                                 Command="{Binding CopyCalculatedValuesCommand}"
                                 FontSize="12"
                                 HeightRequest="30"
-                                Text="{x:Static resources:AddRecipePageResources.CopyCalculated}"/>
+                                Text="{services:Translate BaseName=AddRecipePageResources, Key=CopyCalculated}"/>
                     </Grid>
                     
                     <Grid ColumnDefinitions="*,*" ColumnSpacing="10" RowDefinitions="Auto,Auto" RowSpacing="10">
                         <StackLayout Grid.Row="0" Grid.Column="0" Spacing="5">
-                            <Label Text="{x:Static resources:AddRecipePageResources.CaloriesLabel}" FontAttributes="Bold" />
+                            <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=CaloriesLabel}" FontAttributes="Bold" />
                             <Entry Placeholder="0.0" 
                                    Keyboard="Numeric" 
                                    Text="{Binding Calories}"
@@ -300,7 +301,7 @@
                         </StackLayout>
                         
                         <StackLayout Grid.Row="0" Grid.Column="1" Spacing="5">
-                            <Label Text="{x:Static resources:AddRecipePageResources.ProteinLabel}" FontAttributes="Bold" />
+                            <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=ProteinLabel}" FontAttributes="Bold" />
                             <Entry Placeholder="0.0" 
                                    Keyboard="Numeric" 
                                    Text="{Binding Protein}"
@@ -308,7 +309,7 @@
                         </StackLayout>
                         
                         <StackLayout Grid.Row="1" Grid.Column="0" Spacing="5">
-                            <Label Text="{x:Static resources:AddRecipePageResources.FatLabel}" FontAttributes="Bold" />
+                            <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=FatLabel}" FontAttributes="Bold" />
                             <Entry Placeholder="0.0" 
                                    Keyboard="Numeric" 
                                    Text="{Binding Fat}"
@@ -316,7 +317,7 @@
                         </StackLayout>
                         
                         <StackLayout Grid.Row="1" Grid.Column="1" Spacing="5">
-                            <Label Text="{x:Static resources:AddRecipePageResources.CarbsLabel}" FontAttributes="Bold" />
+                            <Label Text="{services:Translate BaseName=AddRecipePageResources, Key=CarbsLabel}" FontAttributes="Bold" />
                             <Entry Placeholder="0.0" 
                                    Keyboard="Numeric" 
                                    Text="{Binding Carbs}"

--- a/Views/ArchivePage.xaml
+++ b/Views/ArchivePage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              x:Class="Foodbook.Views.ArchivePage"

--- a/Views/HomePage.xaml
+++ b/Views/HomePage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:converters="clr-namespace:Foodbook.Converters"
@@ -8,7 +9,7 @@
              x:Class="Foodbook.Views.HomePage"
              x:Name="HomePageView"
              x:DataType="vm:HomeViewModel"
-             Title="{x:Static resources:HomePageResources.Title}"
+             Title="{services:Translate BaseName=HomePageResources, Key=Title}"
              BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}">
     <ContentPage.Resources>
         <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
@@ -118,13 +119,13 @@
                    Margin="0,0,0,20"
                    Padding="20,16">
                 <StackLayout>
-                    <Label Text="{x:Static resources:HomePageResources.Welcome}"
+                    <Label Text="{services:Translate BaseName=HomePageResources, Key=Welcome}"
                            FontSize="26"
                            FontAttributes="Bold"
                            HorizontalTextAlignment="Center"
                            TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                            Margin="0,4" />
-                    <Label Text="{x:Static resources:HomePageResources.Subtitle}"
+                    <Label Text="{services:Translate BaseName=HomePageResources, Key=Subtitle}"
                            FontSize="14"
                            HorizontalTextAlignment="Center"
                            TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray300}}"
@@ -154,9 +155,9 @@
                         <!-- Przepisy -->
                         <StackLayout Grid.Column="0">
                             <Label Text="📖" Style="{StaticResource EmojiStyle}" />
-                            <Label Text="{x:Static resources:HomePageResources.Recipes}" Style="{StaticResource CardTitleStyle}" />
+                            <Label Text="{services:Translate BaseName=HomePageResources, Key=Recipes}" Style="{StaticResource CardTitleStyle}" />
                             <Label Text="{Binding RecipeCount}" Style="{StaticResource StatNumberStyle}" />
-                            <Label Text="{x:Static resources:HomePageResources.SavedRecipes}" Style="{StaticResource StatDescriptionStyle}" />
+                            <Label Text="{services:Translate BaseName=HomePageResources, Key=SavedRecipes}" Style="{StaticResource StatDescriptionStyle}" />
                         </StackLayout>
                         
                         <!-- Separator Line -->
@@ -168,9 +169,9 @@
                         <!-- Plany -->
                         <StackLayout Grid.Column="2">
                             <Label Text="📋" Style="{StaticResource EmojiStyle}" />
-                            <Label Text="{x:Static resources:HomePageResources.Plans}" Style="{StaticResource CardTitleStyle}" />
+                            <Label Text="{services:Translate BaseName=HomePageResources, Key=Plans}" Style="{StaticResource CardTitleStyle}" />
                             <Label Text="{Binding PlanCount}" Style="{StaticResource StatNumberStyle}" />
-                            <Label Text="{x:Static resources:HomePageResources.ActiveLists}" Style="{StaticResource StatDescriptionStyle}" />
+                            <Label Text="{services:Translate BaseName=HomePageResources, Key=ActiveLists}" Style="{StaticResource StatDescriptionStyle}" />
                         </StackLayout>
                     </Grid>
                 </Frame>
@@ -181,7 +182,7 @@
                     <StackLayout>
                         <StackLayout Orientation="Horizontal" HorizontalOptions="Center" Spacing="8" Margin="0,0,0,16">
                             <Label Text="📅" FontSize="24" />
-                            <Label Text="{x:Static resources:HomePageResources.PlannedMealsHeader}" Style="{StaticResource CardTitleStyle}" Margin="0" />
+                            <Label Text="{services:Translate BaseName=HomePageResources, Key=PlannedMealsHeader}" Style="{StaticResource CardTitleStyle}" Margin="0" />
                         </StackLayout>
                         
                         <!-- Period Selection Button for Planned Meals -->
@@ -200,7 +201,7 @@
                                HorizontalTextAlignment="Center"
                                TextColor="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}"
                                Margin="0,0,0,12"
-                               Text="{x:Static resources:HomePageResources.ClickRecipeHint}" />
+                               Text="{services:Translate BaseName=HomePageResources, Key=ClickRecipeHint}" />
                         
                         <!-- Scrollable CollectionView with limited height -->
                         <ScrollView MaximumHeightRequest="250" 
@@ -259,7 +260,7 @@
                     <StackLayout>
                         <StackLayout Orientation="Horizontal" HorizontalOptions="Center" Spacing="8" Margin="0,0,0,16">
                             <Label Text="📊" FontSize="24" />
-                            <Label Text="{x:Static resources:HomePageResources.NutritionStatsHeader}" Style="{StaticResource CardTitleStyle}" Margin="0" />
+                            <Label Text="{services:Translate BaseName=HomePageResources, Key=NutritionStatsHeader}" Style="{StaticResource CardTitleStyle}" Margin="0" />
                         </StackLayout>
                         
                         <!-- Period Selection Button -->
@@ -283,7 +284,7 @@
                                Margin="0,0,0,12">
                             <StackLayout>
                                 <Label Text="🔥" FontSize="28" HorizontalTextAlignment="Center" />
-                                <Label Text="{x:Static resources:HomePageResources.Calories}"
+                                <Label Text="{services:Translate BaseName=HomePageResources, Key=Calories}"
                                        FontSize="16"
                                        FontAttributes="Bold"
                                        HorizontalTextAlignment="Center"
@@ -308,7 +309,7 @@
                                    BorderColor="Transparent">
                                 <StackLayout>
                                     <Label Text="🥩" FontSize="20" HorizontalTextAlignment="Center" />
-                                    <Label Text="{x:Static resources:HomePageResources.Protein}"
+                                    <Label Text="{services:Translate BaseName=HomePageResources, Key=Protein}"
                                            FontSize="12"
                                            FontAttributes="Bold"
                                            HorizontalTextAlignment="Center"
@@ -327,7 +328,7 @@
                                    BorderColor="Transparent">
                                 <StackLayout>
                                     <Label Text="🌾" FontSize="20" HorizontalTextAlignment="Center" />
-                                    <Label Text="{x:Static resources:HomePageResources.Carbs}"
+                                    <Label Text="{services:Translate BaseName=HomePageResources, Key=Carbs}"
                                            FontSize="12"
                                            FontAttributes="Bold"
                                            HorizontalTextAlignment="Center"
@@ -346,7 +347,7 @@
                                    BorderColor="Transparent">
                                 <StackLayout>
                                     <Label Text="🧈" FontSize="20" HorizontalTextAlignment="Center" />
-                                    <Label Text="{x:Static resources:HomePageResources.Fats}"
+                                    <Label Text="{services:Translate BaseName=HomePageResources, Key=Fats}"
                                            FontSize="12"
                                            FontAttributes="Bold"
                                            HorizontalTextAlignment="Center"
@@ -362,7 +363,7 @@
                                HorizontalTextAlignment="Center"
                                TextColor="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}"
                                Margin="0,16,0,0"
-                               Text="{x:Static resources:HomePageResources.NoNutritionData}" />
+                               Text="{services:Translate BaseName=HomePageResources, Key=NoNutritionData}" />
                     </StackLayout>
                 </Frame>
 
@@ -370,12 +371,12 @@
                 <Frame Grid.Row="3" Grid.Column="0" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
                         <Label Text="📁" Style="{StaticResource EmojiStyle}" />
-                        <Label Text="{x:Static resources:HomePageResources.Archive}" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{services:Translate BaseName=HomePageResources, Key=Archive}" Style="{StaticResource CardTitleStyle}" />
                         <Label Text="{Binding ArchivedPlanCount}" Style="{StaticResource StatNumberStyle}" />
-                        <Label Text="{x:Static resources:HomePageResources.InArchive}" Style="{StaticResource StatDescriptionStyle}" />
+                        <Label Text="{services:Translate BaseName=HomePageResources, Key=InArchive}" Style="{StaticResource StatDescriptionStyle}" />
                         <Button Clicked="OnArchiveClicked"
                                 Style="{StaticResource CardButtonStyle}"
-                                Text="{x:Static resources:HomePageResources.GoToArchive}" />
+                                Text="{services:Translate BaseName=HomePageResources, Key=GoToArchive}" />
                     </StackLayout>
                 </Frame>
 
@@ -383,8 +384,8 @@
                 <Frame Grid.Row="3" Grid.Column="1" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
                         <Label Text="Ustawienia" Style="{StaticResource EmojiStyle}" />
-                        <Label Text="{x:Static resources:HomePageResources.Settings}" Style="{StaticResource CardTitleStyle}" />
-                        <Label Text="{x:Static resources:HomePageResources.Customize}"
+                        <Label Text="{services:Translate BaseName=HomePageResources, Key=Settings}" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{services:Translate BaseName=HomePageResources, Key=Customize}"
                                FontSize="16"
                                HorizontalTextAlignment="Center"
                                TextColor="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}"

--- a/Views/IngredientFormPage.xaml
+++ b/Views/IngredientFormPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              xmlns:converters="clr-namespace:Foodbook.Converters"
              xmlns:resources="clr-namespace:FoodbookApp.Localization"
@@ -24,15 +25,15 @@
                    Margin="0,0,0,10" />
             
             <!-- Basic Information Section -->
-            <Label Text="{x:Static resources:IngredientFormPageResources.BasicInfoHeader}"
+            <Label Text="{services:Translate BaseName=IngredientFormPageResources, Key=BasicInfoHeader}"
                    FontSize="18"
                    FontAttributes="Bold"
                    Margin="0,10,0,5" />
             
             <!-- Name Field -->
             <StackLayout Spacing="5">
-                <Label Text="{x:Static resources:IngredientFormPageResources.NameLabel}" FontAttributes="Bold" />
-                <Entry Placeholder="{x:Static resources:IngredientFormPageResources.NamePlaceholder}"
+                <Label Text="{services:Translate BaseName=IngredientFormPageResources, Key=NameLabel}" FontAttributes="Bold" />
+                <Entry Placeholder="{services:Translate BaseName=IngredientFormPageResources, Key=NamePlaceholder}"
                        Text="{Binding Name}"
                        ClearButtonVisibility="WhileEditing" />
             </StackLayout>
@@ -41,7 +42,7 @@
             <Grid ColumnDefinitions="2*,*" ColumnSpacing="10">
                 <!-- Quantity Field -->
                 <StackLayout Grid.Column="0" Spacing="5">
-                    <Label Text="{x:Static resources:IngredientFormPageResources.QuantityLabel}" FontAttributes="Bold" />
+                    <Label Text="{services:Translate BaseName=IngredientFormPageResources, Key=QuantityLabel}" FontAttributes="Bold" />
                     <Entry Placeholder="100" 
                            Keyboard="Numeric" 
                            Text="{Binding Quantity}"
@@ -51,15 +52,15 @@
                 
                 <!-- Unit Field -->
                 <StackLayout Grid.Column="1" Spacing="5">
-                    <Label Text="{x:Static resources:IngredientFormPageResources.UnitLabel}" FontAttributes="Bold" />
-                    <Picker Title="{x:Static resources:IngredientFormPageResources.UnitPickerTitle}"
+                    <Label Text="{services:Translate BaseName=IngredientFormPageResources, Key=UnitLabel}" FontAttributes="Bold" />
+                    <Picker Title="{services:Translate BaseName=IngredientFormPageResources, Key=UnitPickerTitle}"
                             ItemsSource="{Binding Units}"
                             SelectedItem="{Binding SelectedUnit}" />
                 </StackLayout>
             </Grid>
             
             <!-- Nutritional Information Section -->
-            <Label Text="{x:Static resources:IngredientFormPageResources.NutritionHeader}"
+            <Label Text="{services:Translate BaseName=IngredientFormPageResources, Key=NutritionHeader}"
                    FontSize="18"
                    FontAttributes="Bold"
                    Margin="0,20,0,5" />
@@ -68,12 +69,12 @@
             <StackLayout Spacing="10">
                 <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
                     <Label Grid.Column="0"
-                           Text="{x:Static resources:IngredientFormPageResources.VerifyLabel}"
+                           Text="{services:Translate BaseName=IngredientFormPageResources, Key=VerifyLabel}"
                            FontSize="14"
                            FontAttributes="Bold"
                            VerticalOptions="Center" />
                     <Button Grid.Column="1"
-                            Text="🔍 {x:Static resources:IngredientFormPageResources.VerifyButton}"
+                            Text="🔍 {services:Translate BaseName=IngredientFormPageResources, Key=VerifyButton}"
                             Command="{Binding VerifyNutritionCommand}"
                             TextColor="White"
                             FontSize="12"
@@ -135,7 +136,7 @@
             
             <!-- Recipe Info (if applicable) -->
             <StackLayout Spacing="5" IsVisible="{Binding IsPartOfRecipe}" Margin="0,15,0,0">
-                <Label Text="{x:Static resources:IngredientFormPageResources.InfoLabel}"
+                <Label Text="{services:Translate BaseName=IngredientFormPageResources, Key=InfoLabel}"
                        FontSize="14"
                        FontAttributes="Bold" />
                 <Frame BackgroundColor="LightBlue" 

--- a/Views/IngredientsPage.xaml
+++ b/Views/IngredientsPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
             xmlns:converters="clr-namespace:Foodbook.Converters"
@@ -8,7 +9,7 @@
              x:Class="Foodbook.Views.IngredientsPage"
              x:Name="ThisPage"
              x:DataType="vm:IngredientsViewModel"
-             Title="{x:Static resources:IngredientsPageResources.Title}">
+             Title="{services:Translate BaseName=IngredientsPageResources, Key=Title}">
 
     <ContentPage.Resources>
         <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
@@ -27,7 +28,7 @@
         <!-- Search bar -->
         <SearchBar Grid.Row="1"
                    Text="{Binding SearchText}"
-                   Placeholder="{x:Static resources:IngredientsPageResources.SearchPlaceholder}"
+                   Placeholder="{services:Translate BaseName=IngredientsPageResources, Key=SearchPlaceholder}"
                    Margin="10,0"
                    IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
 
@@ -44,7 +45,7 @@
                     <Button Command="{Binding AddCommand}"
                             TextColor="White"
                             HeightRequest="45"
-                            Text="{x:Static resources:IngredientsPageResources.AddButton}" />
+                            Text="{services:Translate BaseName=IngredientsPageResources, Key=AddButton}" />
                 </Grid>
 
                 <CollectionView Grid.Row="1"
@@ -144,11 +145,11 @@
                     
                     <CollectionView.EmptyView>
                         <StackLayout HorizontalOptions="Center" VerticalOptions="Center" Padding="20">
-                            <Label Text="{x:Static resources:IngredientsPageResources.EmptyTitle}"
+                            <Label Text="{services:Translate BaseName=IngredientsPageResources, Key=EmptyTitle}"
                                    FontSize="18"
                                    HorizontalOptions="Center"
                                    TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}" />
-                            <Label Text="{x:Static resources:IngredientsPageResources.EmptyHint}"
+                            <Label Text="{services:Translate BaseName=IngredientsPageResources, Key=EmptyHint}"
                                    FontSize="14"
                                    HorizontalOptions="Center"
                                    TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"

--- a/Views/MealFormPage.xaml
+++ b/Views/MealFormPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              x:Class="Foodbook.Views.MealFormPage"
              x:Name="ThisPage"

--- a/Views/PlannerPage.xaml
+++ b/Views/PlannerPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              xmlns:converters="clr-namespace:Foodbook.Converters"
@@ -8,7 +9,7 @@
              x:Class="Foodbook.Views.PlannerPage"
              x:Name="ThisPage"
              x:DataType="vm:PlannerViewModel"
-             Title="{x:Static resources:PlannerPageResources.Title}">
+             Title="{services:Translate BaseName=PlannerPageResources, Key=Title}">
     
     <ContentPage.Resources>
         <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
@@ -61,7 +62,7 @@
                    HorizontalTextAlignment="Center"
                    TextColor="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}"
                    Margin="0,10,0,0"
-                   Text="{x:Static resources:PlannerPageResources.LoadingTip}" />
+                   Text="{services:Translate BaseName=PlannerPageResources, Key=LoadingTip}" />
         </StackLayout>
 
         <!-- Main content -->
@@ -73,7 +74,7 @@
                 <Grid ColumnDefinitions="*,*" ColumnSpacing="15" Margin="0,5">
                     <!-- Data Od - maksymalnie po lewej -->
                     <VerticalStackLayout Grid.Column="0" HorizontalOptions="Start">
-                        <Label Text="{x:Static resources:PlannerPageResources.DateFrom}"
+                        <Label Text="{services:Translate BaseName=PlannerPageResources, Key=DateFrom}"
                                FontSize="12"
                                FontAttributes="Bold"
                                TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
@@ -86,7 +87,7 @@
                     
                     <!-- Data Do - maksymalnie po prawej -->
                     <VerticalStackLayout Grid.Column="1" HorizontalOptions="End">
-                        <Label Text="{x:Static resources:PlannerPageResources.DateTo}"
+                        <Label Text="{services:Translate BaseName=PlannerPageResources, Key=DateTo}"
                                FontSize="12"
                                FontAttributes="Bold"
                                TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
@@ -100,7 +101,7 @@
                 
                 <!-- Sekcja ilości posiłków - wyśrodkowana, niżej -->
                 <HorizontalStackLayout HorizontalOptions="Center" Spacing="10">
-                    <Label Text="{x:Static resources:PlannerPageResources.MealsPerDay}"
+                    <Label Text="{services:Translate BaseName=PlannerPageResources, Key=MealsPerDay}"
                            VerticalOptions="Center"
                            FontSize="14"
                            FontAttributes="Bold"
@@ -214,7 +215,7 @@
                                                 Padding="12,6"
                                                 WidthRequest="120"
                                                 HeightRequest="32"
-                                                Text="{x:Static resources:PlannerPageResources.AddMeal}" />
+                                                Text="{services:Translate BaseName=PlannerPageResources, Key=AddMeal}" />
                                     </StackLayout>
                                 </VerticalStackLayout>
                             </Frame>
@@ -225,7 +226,7 @@
                 <!-- Przycisk Zapisz - wyśrodkowany -->
                 <HorizontalStackLayout Spacing="10" Margin="0,20,0,0" HorizontalOptions="Center">
                     <Button Command="{Binding SaveCommand}"
-                            Text="{x:Static resources:PlannerPageResources.Save}" />
+                            Text="{services:Translate BaseName=PlannerPageResources, Key=Save}" />
                 </HorizontalStackLayout>
             </VerticalStackLayout>
         </ScrollView>

--- a/Views/RecipesPage.xaml
+++ b/Views/RecipesPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:converters="clr-namespace:Foodbook.Converters"
@@ -8,7 +9,7 @@
              x:Class="Foodbook.Views.RecipesPage"
              x:Name="ThisPage"
              x:DataType="vm:RecipeViewModel"
-             Title="{x:Static resources:RecipesPageResources.Title}">
+             Title="{services:Translate BaseName=RecipesPageResources, Key=Title}">
     
     <ContentPage.Resources>
         <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
@@ -26,7 +27,7 @@
         <!-- Search bar -->
         <SearchBar Grid.Row="1"
                    Text="{Binding SearchText}"
-                   Placeholder="{x:Static resources:RecipesPageResources.SearchPlaceholder}"
+                   Placeholder="{services:Translate BaseName=RecipesPageResources, Key=SearchPlaceholder}"
                    Margin="10,0"
                    IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
 
@@ -42,7 +43,7 @@
                       Margin="10">
                     <Button Clicked="OnAddRecipeClicked"
                             HeightRequest="45"
-                            Text="{x:Static resources:RecipesPageResources.AddButton}" />
+                            Text="{services:Translate BaseName=RecipesPageResources, Key=AddButton}" />
                 </Grid>
 
                 <CollectionView Grid.Row="1"
@@ -131,11 +132,11 @@
                     
                     <CollectionView.EmptyView>
                         <StackLayout HorizontalOptions="Center" VerticalOptions="Center" Padding="20">
-                            <Label Text="{x:Static resources:RecipesPageResources.EmptyTitle}"
+                            <Label Text="{services:Translate BaseName=RecipesPageResources, Key=EmptyTitle}"
                                    FontSize="18"
                                    HorizontalOptions="Center"
                                    TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}" />
-                            <Label Text="{x:Static resources:RecipesPageResources.EmptyHint}"
+                            <Label Text="{services:Translate BaseName=RecipesPageResources, Key=EmptyHint}"
                                    FontSize="14"
                                    HorizontalOptions="Center"
                                    TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"

--- a/Views/SettingsPage.xaml
+++ b/Views/SettingsPage.xaml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              x:Class="Foodbook.Views.SettingsPage"
-             Title="Ustawienia"
+             Title="{services:Translate BaseName=SettingsPageResources, Key=Title}"
              BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}">
     
     <ContentPage.Resources>
@@ -80,13 +81,13 @@
                    Margin="0,0,0,20"
                    Padding="20,16">
                 <StackLayout>
-                    <Label Text="Ustawienia"
+                    <Label Text="{services:Translate BaseName=SettingsPageResources, Key=HeaderTitle}"
                            FontSize="26"
                            FontAttributes="Bold"
                            HorizontalTextAlignment="Center"
                            TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                            Margin="0,4" />
-                    <Label Text="Personalizuj swoja aplikacje"
+                    <Label Text="{services:Translate BaseName=SettingsPageResources, Key=HeaderSubtitle}"
                            FontSize="14"
                            HorizontalTextAlignment="Center"
                            TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray300}}"
@@ -103,46 +104,46 @@
                 <!-- Theme Settings Card -->
                 <Frame Grid.Row="0" Grid.Column="0" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
-                        <Label Text="Motyw" Style="{StaticResource CardTitleStyle}" />
-                        <Label Text="Jasny / ciemny"
+                        <Label Text="{services:Translate BaseName=SettingsPageResources, Key=ThemeTitle}" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{services:Translate BaseName=SettingsPageResources, Key=ThemeDescription}"
                                Style="{StaticResource DescriptionStyle}" />
                         <Button Style="{StaticResource DisabledButtonStyle}"
                                 IsEnabled="False"
-                                Text="Wkrotce" />
+                                Text="{services:Translate BaseName=SettingsPageResources, Key=ComingSoon}" />
                     </StackLayout>
                 </Frame>
 
                 <!-- Language Settings Card -->
                 <Frame Grid.Row="0" Grid.Column="1" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
-                        <Label Text="Jezyk" Style="{StaticResource CardTitleStyle}" />
-                        <Label Text="PL / EN"
+                        <Label Text="{services:Translate BaseName=SettingsPageResources, Key=LanguageTitle}" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{services:Translate BaseName=SettingsPageResources, Key=LanguageDescription}"
                                Style="{StaticResource DescriptionStyle}" />
-                        <Button Style="{StaticResource DisabledButtonStyle}"
-                                IsEnabled="False"
-                                Text="Wkrotce" />
+                        <Picker ItemsSource="{Binding AvailableCultures}"
+                                ItemDisplayBinding="{Binding NativeName}"
+                                SelectedItem="{Binding SelectedCulture}" />
                     </StackLayout>
                 </Frame>
 
                 <!-- Version Info Card -->
                 <Frame Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
-                        <Label Text="Informacje o wersji" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{services:Translate BaseName=SettingsPageResources, Key=VersionInfoTitle}" Style="{StaticResource CardTitleStyle}" />
                         
                         <StackLayout Spacing="8" Margin="0,8">
-                            <Label Text="Wersja 1.0"
+                            <Label Text="{services:Translate BaseName=SettingsPageResources, Key=VersionNumber}"
                                    FontSize="16"
                                    FontAttributes="Bold"
                                    HorizontalTextAlignment="Center"
                                    TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                            
-                            <Label Text="Autor: Przemyslaw Przybyszewski"
+
+                            <Label Text="{services:Translate BaseName=SettingsPageResources, Key=AuthorLabel}"
                                    Style="{StaticResource InfoTextStyle}" />
-                            
-                            <Label Text="All rights reserved 2025"
+
+                            <Label Text="{services:Translate BaseName=SettingsPageResources, Key=RightsLabel}"
                                    Style="{StaticResource InfoTextStyle}" />
-                            
-                            <Label Text="FoodBook App"
+
+                            <Label Text="{services:Translate BaseName=SettingsPageResources, Key=AppName}"
                                    FontSize="14"
                                    FontAttributes="Bold"
                                    HorizontalTextAlignment="Center"
@@ -155,12 +156,12 @@
                 <!-- Data Export Card -->
                 <Frame Grid.Row="2" Grid.ColumnSpan="2" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
-                        <Label Text="Eksport danych" Style="{StaticResource CardTitleStyle}" />
-                        <Label Text="Zapisz przepisy i plany"
+                        <Label Text="{services:Translate BaseName=SettingsPageResources, Key=DataExportTitle}" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{services:Translate BaseName=SettingsPageResources, Key=DataExportDescription}"
                                Style="{StaticResource DescriptionStyle}" />
                         <Button Style="{StaticResource DisabledButtonStyle}"
                                 IsEnabled="False"
-                                Text="Wkrotce" />
+                                Text="{services:Translate BaseName=SettingsPageResources, Key=ComingSoon}" />
                     </StackLayout>
                 </Frame>
 

--- a/Views/SettingsPage.xaml.cs
+++ b/Views/SettingsPage.xaml.cs
@@ -4,8 +4,9 @@ namespace Foodbook.Views;
 
 public partial class SettingsPage : ContentPage
 {
-    public SettingsPage()
+    public SettingsPage(Foodbook.ViewModels.SettingsViewModel vm)
     {
         InitializeComponent();
+        BindingContext = vm;
     }
 }

--- a/Views/ShoppingListDetailPage.xaml
+++ b/Views/ShoppingListDetailPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              xmlns:converters="clr-namespace:Foodbook.Converters"
@@ -8,7 +9,7 @@
              x:Class="Foodbook.Views.ShoppingListDetailPage"
              x:Name="ThisPage"
              x:DataType="vm:ShoppingListDetailViewModel"
-             Title="{x:Static resources:ShoppingListDetailPageResources.Title}">
+             Title="{services:Translate BaseName=ShoppingListDetailPageResources, Key=Title}">
     <ContentPage.Resources>
         <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
     </ContentPage.Resources>
@@ -22,7 +23,7 @@
                        FontAttributes="Bold"
                        TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                        Margin="0,0,0,10"
-                       Text="{x:Static resources:ShoppingListDetailPageResources.ToBuy}" />
+                       Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=ToBuy}" />
                 
                 <!-- Nagłówki kolumn dla produktów do kupienia -->
                 <Grid ColumnDefinitions="Auto,2*,Auto,Auto,Auto" 
@@ -30,10 +31,10 @@
                       ColumnSpacing="5" 
                       BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}">
                     <Label Grid.Column="0" Text="✓" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
-                    <Label Grid.Column="1" Text="{x:Static resources:ShoppingListDetailPageResources.NameHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" />
-                    <Label Grid.Column="2" Text="{x:Static resources:ShoppingListDetailPageResources.QuantityHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
-                    <Label Grid.Column="3" Text="{x:Static resources:ShoppingListDetailPageResources.UnitHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
-                    <Label Grid.Column="4" Text="{x:Static resources:ShoppingListDetailPageResources.ActionsHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
+                    <Label Grid.Column="1" Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=NameHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" />
+                    <Label Grid.Column="2" Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=QuantityHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
+                    <Label Grid.Column="3" Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=UnitHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
+                    <Label Grid.Column="4" Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=ActionsHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
                 </Grid>
                 
                 <!-- Lista produktów do kupienia -->
@@ -81,7 +82,7 @@
                 
                 <Button Command="{Binding AddItemCommand}"
                         Margin="0,10,0,0"
-                        Text="{x:Static resources:ShoppingListDetailPageResources.AddItem}" />
+                        Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=AddItem}" />
             </StackLayout>
 
             <!-- Separator -->
@@ -95,7 +96,7 @@
                        FontAttributes="Bold"
                        TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}"
                        Margin="0,0,0,10"
-                       Text="{x:Static resources:ShoppingListDetailPageResources.Collected}" />
+                       Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=Collected}" />
                 
                 <!-- Nagłówki kolumn dla produktów zebranych -->
                 <Grid ColumnDefinitions="Auto,2*,Auto,Auto,Auto" 
@@ -103,10 +104,10 @@
                       ColumnSpacing="5" 
                       BackgroundColor="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}">
                     <Label Grid.Column="0" Text="✓" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
-                    <Label Grid.Column="1" Text="{x:Static resources:ShoppingListDetailPageResources.NameHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" />
-                    <Label Grid.Column="2" Text="{x:Static resources:ShoppingListDetailPageResources.QuantityHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
-                    <Label Grid.Column="3" Text="{x:Static resources:ShoppingListDetailPageResources.UnitHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
-                    <Label Grid.Column="4" Text="{x:Static resources:ShoppingListDetailPageResources.ActionsHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
+                    <Label Grid.Column="1" Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=NameHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" />
+                    <Label Grid.Column="2" Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=QuantityHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
+                    <Label Grid.Column="3" Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=UnitHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
+                    <Label Grid.Column="4" Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=ActionsHeader}" FontAttributes="Bold" TextColor="White" VerticalTextAlignment="Center" HorizontalTextAlignment="Center" />
                 </Grid>
                 
                 <!-- Lista produktów zebranych -->
@@ -162,7 +163,7 @@
                 </CollectionView>
                 
                 <!-- Informacja gdy brak zebranych produktów -->
-                <Label Text="{x:Static resources:ShoppingListDetailPageResources.NoCollected}"
+                <Label Text="{services:Translate BaseName=ShoppingListDetailPageResources, Key=NoCollected}"
                        TextColor="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}"
                        HorizontalTextAlignment="Center"
                        Margin="0,20"

--- a/Views/ShoppingListPage.xaml
+++ b/Views/ShoppingListPage.xaml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:services="clr-namespace:Foodbook.Services"
              xmlns:models="clr-namespace:Foodbook.Models"
              xmlns:vm="clr-namespace:Foodbook.ViewModels"
              xmlns:resources="clr-namespace:FoodbookApp.Localization"
              x:Class="Foodbook.Views.ShoppingListPage"
              x:Name="ThisPage"
              x:DataType="vm:ShoppingListViewModel"
-             Title="{x:Static resources:ShoppingListPageResources.Title}">
+             Title="{services:Translate BaseName=ShoppingListPageResources, Key=Title}">
     <CollectionView ItemsSource="{Binding Plans}" Margin="10" SelectionMode="None">
         <CollectionView.ItemTemplate>
             <DataTemplate x:DataType="models:Plan">
@@ -63,12 +64,12 @@
                        HorizontalOptions="Center"
                        TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"
                        Margin="0,0,0,20" />
-                <Label Text="{x:Static resources:ShoppingListPageResources.EmptyTitle}"
+                <Label Text="{services:Translate BaseName=ShoppingListPageResources, Key=EmptyTitle}"
                        FontSize="18"
                        FontAttributes="Bold"
                        HorizontalOptions="Center"
                        TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}" />
-                <Label Text="{x:Static resources:ShoppingListPageResources.EmptyHint}"
+                <Label Text="{services:Translate BaseName=ShoppingListPageResources, Key=EmptyHint}"
                        FontSize="16"
                        HorizontalOptions="Center"
                        TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"


### PR DESCRIPTION
## Summary
- set neutral resources to English
- add runtime LocalizationResourceManager
- extend localization service with event
- introduce Translate markup extension
- add SettingsViewModel and bind language picker
- update all pages to use new translation extension

## Testing
- `dotnet build -v minimal` *(fails: The target platform identifier android was not recognized)*

------
https://chatgpt.com/codex/tasks/task_b_687d474d9b288330af285f6f57c11694