### PR TITLE
Add runtime translation support

### DIFF
--- a/FoodbookApp.csproj
+++ b/FoodbookApp.csproj
@@ -39,7 +39,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'tizen'">6.5</SupportedOSPlatformVersion>
-		<NeutralLanguage>pl</NeutralLanguage>
+                <NeutralLanguage>en</NeutralLanguage>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Localization/SettingsPageResources.pl-PL.resx
+++ b/Localization/SettingsPageResources.pl-PL.resx
@@ -28,10 +28,10 @@
     <value>Jasny / ciemny</value>
   </data>
   <data name="LanguageTitle" xml:space="preserve">
-    <value>Jezyk</value>
+    <value>Język</value>
   </data>
   <data name="LanguageDescription" xml:space="preserve">
-    <value>PL / EN</value>
+    <value>Wybierz język</value>
   </data>
   <data name="VersionInfoTitle" xml:space="preserve">
     <value>Informacje o wersji</value>

--- a/Localization/SettingsPageResources.resx
+++ b/Localization/SettingsPageResources.resx
@@ -31,7 +31,7 @@
     <value>Language</value>
   </data>
   <data name="LanguageDescription" xml:space="preserve">
-    <value>PL / EN</value>
+    <value>Choose language</value>
   </data>
   <data name="VersionInfoTitle" xml:space="preserve">
     <value>Version info</value>

--- a/Services/ILocalizationService.cs
+++ b/Services/ILocalizationService.cs
@@ -5,6 +5,7 @@ namespace Foodbook.Services;
 public interface ILocalizationService
 {
     CultureInfo CurrentCulture { get; }
+    event EventHandler? CultureChanged;
     void SetCulture(string cultureName);
     string GetString(string baseName, string key);
 }

--- a/Services/LocalizationService.cs
+++ b/Services/LocalizationService.cs
@@ -10,6 +10,7 @@ public class LocalizationService : ILocalizationService
     private readonly Dictionary<string, ResourceManager> _resourceManagers = new();
 
     public CultureInfo CurrentCulture { get; private set; } = CultureInfo.CurrentUICulture;
+    public event EventHandler? CultureChanged;
 
     public void SetCulture(string cultureName)
     {
@@ -32,6 +33,8 @@ public class LocalizationService : ILocalizationService
         ShoppingListDetailPageResources.Culture = culture;
         ShoppingListPageResources.Culture = culture;
         TabBarResources.Culture = culture;
+
+        CultureChanged?.Invoke(this, EventArgs.Empty);
     }
 
     public string GetString(string baseName, string key)

--- a/Views/SettingsPage.xaml
+++ b/Views/SettingsPage.xaml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:resources="clr-namespace:FoodbookApp.Localization"
              x:Class="Foodbook.Views.SettingsPage"
-             Title="Ustawienia"
+             Title="{x:Static resources:SettingsPageResources.Title}"
              BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}">
     
     <ContentPage.Resources>
@@ -80,13 +81,13 @@
                    Margin="0,0,0,20"
                    Padding="20,16">
                 <StackLayout>
-                    <Label Text="Ustawienia"
+                    <Label Text="{x:Static resources:SettingsPageResources.HeaderTitle}"
                            FontSize="26"
                            FontAttributes="Bold"
                            HorizontalTextAlignment="Center"
                            TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                            Margin="0,4" />
-                    <Label Text="Personalizuj swoja aplikacje"
+                    <Label Text="{x:Static resources:SettingsPageResources.HeaderSubtitle}"
                            FontSize="14"
                            HorizontalTextAlignment="Center"
                            TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray300}}"
@@ -103,46 +104,44 @@
                 <!-- Theme Settings Card -->
                 <Frame Grid.Row="0" Grid.Column="0" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
-                        <Label Text="Motyw" Style="{StaticResource CardTitleStyle}" />
-                        <Label Text="Jasny / ciemny"
+                        <Label Text="{x:Static resources:SettingsPageResources.ThemeTitle}" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{x:Static resources:SettingsPageResources.ThemeDescription}"
                                Style="{StaticResource DescriptionStyle}" />
                         <Button Style="{StaticResource DisabledButtonStyle}"
                                 IsEnabled="False"
-                                Text="Wkrotce" />
+                                Text="{x:Static resources:SettingsPageResources.ComingSoon}" />
                     </StackLayout>
                 </Frame>
 
                 <!-- Language Settings Card -->
                 <Frame Grid.Row="0" Grid.Column="1" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
-                        <Label Text="Jezyk" Style="{StaticResource CardTitleStyle}" />
-                        <Label Text="PL / EN"
-                               Style="{StaticResource DescriptionStyle}" />
-                        <Button Style="{StaticResource DisabledButtonStyle}"
-                                IsEnabled="False"
-                                Text="Wkrotce" />
+                        <Label Text="{x:Static resources:SettingsPageResources.LanguageTitle}" Style="{StaticResource CardTitleStyle}" />
+                        <Picker x:Name="LanguagePicker"
+                                Title="{x:Static resources:SettingsPageResources.LanguageDescription}"
+                                SelectedIndexChanged="OnLanguageChanged" />
                     </StackLayout>
                 </Frame>
 
                 <!-- Version Info Card -->
                 <Frame Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
-                        <Label Text="Informacje o wersji" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{x:Static resources:SettingsPageResources.VersionInfoTitle}" Style="{StaticResource CardTitleStyle}" />
                         
                         <StackLayout Spacing="8" Margin="0,8">
-                            <Label Text="Wersja 1.0"
+                            <Label Text="{x:Static resources:SettingsPageResources.VersionNumber}"
                                    FontSize="16"
                                    FontAttributes="Bold"
                                    HorizontalTextAlignment="Center"
                                    TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
                             
-                            <Label Text="Autor: Przemyslaw Przybyszewski"
+                            <Label Text="{x:Static resources:SettingsPageResources.AuthorLabel}"
                                    Style="{StaticResource InfoTextStyle}" />
                             
-                            <Label Text="All rights reserved 2025"
+                            <Label Text="{x:Static resources:SettingsPageResources.RightsLabel}"
                                    Style="{StaticResource InfoTextStyle}" />
                             
-                            <Label Text="FoodBook App"
+                            <Label Text="{x:Static resources:SettingsPageResources.AppName}"
                                    FontSize="14"
                                    FontAttributes="Bold"
                                    HorizontalTextAlignment="Center"
@@ -155,12 +154,12 @@
                 <!-- Data Export Card -->
                 <Frame Grid.Row="2" Grid.ColumnSpan="2" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
-                        <Label Text="Eksport danych" Style="{StaticResource CardTitleStyle}" />
-                        <Label Text="Zapisz przepisy i plany"
+                        <Label Text="{x:Static resources:SettingsPageResources.DataExportTitle}" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="{x:Static resources:SettingsPageResources.DataExportDescription}"
                                Style="{StaticResource DescriptionStyle}" />
                         <Button Style="{StaticResource DisabledButtonStyle}"
                                 IsEnabled="False"
-                                Text="Wkrotce" />
+                                Text="{x:Static resources:SettingsPageResources.ComingSoon}" />
                     </StackLayout>
                 </Frame>
 

--- a/Views/SettingsPage.xaml.cs
+++ b/Views/SettingsPage.xaml.cs
@@ -1,11 +1,36 @@
 using Microsoft.Maui.Controls;
+using Foodbook.Services;
+using System.Globalization;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Foodbook.Views;
 
 public partial class SettingsPage : ContentPage
 {
-    public SettingsPage()
+    private readonly ILocalizationService _localizationService;
+    private readonly Dictionary<string, string> _cultures = new()
+    {
+        { "English", "en" },
+        { "Polski", "pl-PL" }
+    };
+
+    public SettingsPage(ILocalizationService localizationService)
     {
         InitializeComponent();
+        _localizationService = localizationService;
+
+        LanguagePicker.ItemsSource = _cultures.Keys.ToList();
+        var current = _cultures.FirstOrDefault(c => c.Value == _localizationService.CurrentCulture.Name).Key;
+        LanguagePicker.SelectedItem = current;
+    }
+
+    private void OnLanguageChanged(object sender, EventArgs e)
+    {
+        if (LanguagePicker.SelectedItem is string key && _cultures.TryGetValue(key, out var culture))
+        {
+            _localizationService.SetCulture(culture);
+            Application.Current.MainPage = new AppShell();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- switch neutral language to English in `csproj`
- expose `CultureChanged` event for localization service
- refresh UI when changing language via new picker
- hook up resources in Settings page
- update language resource texts

## Testing
- `dotnet build` *(fails: maui-android workload missing)*

------
https://chatgpt.com/codex/tasks/task_b_687d474d9b288330af285f6f57c11694