### PR TITLE
Update dotnet.yml

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -8,8 +8,8 @@ on:
 
 jobs:
   test:
-    name: Build and Test
-    runs-on: windows-latest
+    name: Unit Tests
+    runs-on: ubuntu-latest
     
     steps:
     - name: Checkout code
@@ -20,17 +20,14 @@ jobs:
       with:
         dotnet-version: '9.0.x'
         
-    - name: Install MAUI workloads
-      run: dotnet workload install maui
+    - name: Restore dependencies (Tests only)
+      run: dotnet restore FoodbookApp.Tests/FoodbookApp.Tests.csproj
       
-    - name: Restore dependencies
-      run: dotnet restore
-      
-    - name: Build solution
-      run: dotnet build --no-restore --configuration Release
+    - name: Build tests
+      run: dotnet build FoodbookApp.Tests/FoodbookApp.Tests.csproj --no-restore --configuration Release
       
     - name: Run tests
-      run: dotnet test --no-build --configuration Release --verbosity normal --logger trx --results-directory "TestResults"
+      run: dotnet test FoodbookApp.Tests/FoodbookApp.Tests.csproj --no-build --configuration Release --verbosity normal --logger trx --results-directory "TestResults"
       
     - name: Upload test results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for .NET to focus specifically on running unit tests for the `FoodbookApp.Tests` project, and changes the environment from Windows to Ubuntu for improved consistency and efficiency.

**Workflow environment update:**
- Changed the test job runner from `windows-latest` to `ubuntu-latest` for better performance and consistency with typical CI/CD environments.

**Test job simplification and focus:**
- Renamed the test job to "Unit Tests" and removed installation of MAUI workloads, since only the tests are being run. [[1]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L11-R12) [[2]](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L23-R30)
- Updated steps to restore, build, and test only the `FoodbookApp.Tests` project, rather than the full solution, streamlining the workflow for unit testing.