### PR TITLE
Fixes

### DIFF
--- a/FoodbookApp.App/Converters/BoolToColorConverter.cs
+++ b/FoodbookApp.App/Converters/BoolToColorConverter.cs
@@ -14,18 +14,44 @@ public class BoolToColorConverter : IValueConverter
             
             return param switch
             {
-                "Text" => boolValue ? Colors.White : Colors.Black,
+                "Text" => boolValue 
+                    ? Application.Current?.RequestedTheme == AppTheme.Dark 
+                        ? Color.FromArgb("#ac99ea") // PrimaryDark for dark theme
+                        : Color.FromArgb("#512BD4")  // Primary for light theme
+                    : Application.Current?.RequestedTheme == AppTheme.Dark
+                        ? Color.FromArgb("#C8C8C8") // Gray200 for dark theme
+                        : Color.FromArgb("#6E6E6E"), // Gray500 for light theme
                 "Bold" => boolValue ? FontAttributes.Bold : FontAttributes.None,
-                _ => boolValue ? Colors.Green : Colors.Gray
+                "TabBackground" => boolValue 
+                    ? Colors.Transparent // Selected tab has transparent background
+                    : Colors.Transparent, // Unselected tab also transparent
+                "TabBorder" => boolValue 
+                    ? Application.Current?.RequestedTheme == AppTheme.Dark 
+                        ? Color.FromArgb("#ac99ea") // PrimaryDark for dark theme
+                        : Color.FromArgb("#512BD4")  // Primary for light theme
+                    : Colors.Transparent, // No border for unselected tabs
+                _ => boolValue 
+                    ? Application.Current?.RequestedTheme == AppTheme.Dark 
+                        ? Color.FromArgb("#ac99ea") // PrimaryDark for dark theme
+                        : Color.FromArgb("#512BD4")  // Primary for light theme
+                    : Application.Current?.RequestedTheme == AppTheme.Dark
+                        ? Color.FromArgb("#404040") // Gray600 for dark theme
+                        : Color.FromArgb("#ACACAC") // Gray300 for light theme
             };
         }
         
         var paramDefault = parameter?.ToString();
         return paramDefault switch
         {
-            "Text" => Colors.Black,
+            "Text" => Application.Current?.RequestedTheme == AppTheme.Dark
+                ? Color.FromArgb("#C8C8C8") // Gray200 for dark theme
+                : Color.FromArgb("#6E6E6E"), // Gray500 for light theme
             "Bold" => FontAttributes.None,
-            _ => Colors.Gray
+            "TabBackground" => Colors.Transparent,
+            "TabBorder" => Colors.Transparent,
+            _ => Application.Current?.RequestedTheme == AppTheme.Dark
+                ? Color.FromArgb("#404040") // Gray600 for dark theme
+                : Color.FromArgb("#ACACAC") // Gray300 for light theme
         };
     }
 

--- a/FoodbookApp.App/Converters/BoolToColorConverter.cs
+++ b/FoodbookApp.App/Converters/BoolToColorConverter.cs
@@ -131,3 +131,16 @@ public class BoolToTextConverter : IValueConverter
         throw new NotImplementedException();
     }
 }
+
+public class IsNotNullOrEmptyConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        return !string.IsNullOrEmpty(value?.ToString());
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/FoodbookApp.App/Resources/Styles/Colors.xaml
+++ b/FoodbookApp.App/Resources/Styles/Colors.xaml
@@ -10,6 +10,7 @@
     <Color x:Key="PrimaryDark">#ac99ea</Color>
     <Color x:Key="PrimaryDarkText">#242424</Color>
     <Color x:Key="Secondary">#DFD8F7</Color>
+    <Color x:Key="SecondaryDark">#B8A7E8</Color>
     <Color x:Key="SecondaryDarkText">#9880e5</Color>
     <Color x:Key="Tertiary">#2B0B98</Color>
 

--- a/FoodbookApp.App/Resources/Styles/Styles.xaml
+++ b/FoodbookApp.App/Resources/Styles/Styles.xaml
@@ -498,4 +498,51 @@
         <Setter Property="BorderWidth" Value="0" />
     </Style>
 
+    <!-- Floating Action Button (FAB) Style -->
+    <Style x:Key="FloatingActionButton" TargetType="Button">
+        <Setter Property="WidthRequest" Value="56" />
+        <Setter Property="HeightRequest" Value="56" />
+        <Setter Property="CornerRadius" Value="28" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light=White, Dark={StaticResource PrimaryDarkText}}" />
+        <Setter Property="FontSize" Value="24" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="Text" Value="+" />
+        <Setter Property="BorderWidth" Value="0" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="HorizontalOptions" Value="End" />
+        <Setter Property="VerticalOptions" Value="End" />
+        <Setter Property="Margin" Value="0,0,16,16" />
+        <Setter Property="Shadow">
+            <Shadow Brush="{AppThemeBinding Light={StaticResource Gray600}, Dark={StaticResource Gray950}}"
+                    Offset="0,4"
+                    Radius="8"
+                    Opacity="0.3" />
+        </Setter>
+        <Setter Property="VisualStateManager.VisualStateGroups">
+            <VisualStateGroupList>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="Scale" Value="1.0" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Pressed">
+                        <VisualState.Setters>
+                            <Setter Property="Scale" Value="0.96" />
+                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Tertiary}, Dark={StaticResource SecondaryDark}}" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray300}, Dark={StaticResource Gray600}}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray400}}" />
+                            <Setter Property="Opacity" Value="0.6" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateGroupList>
+        </Setter>
+    </Style>
+
 </ResourceDictionary>

--- a/FoodbookApp.App/Resources/Styles/Styles.xaml
+++ b/FoodbookApp.App/Resources/Styles/Styles.xaml
@@ -459,4 +459,43 @@
         <Setter Property="SelectedTabColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray200}}" />
     </Style>
 
+    <!-- Modern Search Bar Style -->
+    <Style x:Key="ModernSearchBarFrame" TargetType="Frame">
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#F5F5F5, Dark=#3A3A3A}" />
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light=#E0E0E0, Dark=#555555}" />
+        <Setter Property="CornerRadius" Value="25" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="HeightRequest" Value="50" />
+        <Setter Property="HasShadow" Value="False" />
+    </Style>
+
+    <Style x:Key="ModernSearchEntry" TargetType="Entry">
+        <Setter Property="BackgroundColor" Value="Transparent" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="PlaceholderColor" Value="{AppThemeBinding Light=#999999, Dark=#CCCCCC}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light=#333333, Dark=#FFFFFF}" />
+        <Setter Property="VerticalOptions" Value="Center" />
+        <Setter Property="FontFamily" Value="OpenSansRegular" />
+    </Style>
+
+    <Style x:Key="SearchIconLabel" TargetType="Label">
+        <Setter Property="Text" Value="🔍" />
+        <Setter Property="FontSize" Value="18" />
+        <Setter Property="HorizontalOptions" Value="Center" />
+        <Setter Property="VerticalOptions" Value="Center" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light=#999999, Dark=#CCCCCC}" />
+    </Style>
+
+    <Style x:Key="ClearSearchButton" TargetType="Button">
+        <Setter Property="Text" Value="✕" />
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="WidthRequest" Value="30" />
+        <Setter Property="HeightRequest" Value="30" />
+        <Setter Property="CornerRadius" Value="15" />
+        <Setter Property="BackgroundColor" Value="Transparent" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light=#999999, Dark=#CCCCCC}" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="BorderWidth" Value="0" />
+    </Style>
+
 </ResourceDictionary>

--- a/FoodbookApp.App/Resources/Styles/Styles.xaml
+++ b/FoodbookApp.App/Resources/Styles/Styles.xaml
@@ -2,8 +2,19 @@
 <?xaml-comp compile="true" ?>
 <ResourceDictionary 
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:converters="clr-namespace:Foodbook.Converters">
 
+    <!-- Converters -->
+    <converters:BoolToColorConverter x:Key="BoolToColorConverter" />
+    <converters:StringToBoolConverter x:Key="StringToBoolConverter" />
+    <converters:DragStateToColorConverter x:Key="DragStateToColorConverter" />
+    <converters:DropZoneToColorConverter x:Key="DropZoneToColorConverter" />
+    <converters:DropZoneBorderColorConverter x:Key="DropZoneBorderColorConverter" />
+    <converters:BoolToTextConverter x:Key="BoolToTextConverter" />
+    <converters:IsNotNullOrEmptyConverter x:Key="IsNotNullOrEmptyConverter" />
+
+    <!-- Existing styles below -->
     <Style TargetType="ActivityIndicator">
         <Setter Property="Color" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource White}}" />
     </Style>

--- a/FoodbookApp.App/Resources/Styles/Styles.xaml
+++ b/FoodbookApp.App/Resources/Styles/Styles.xaml
@@ -545,4 +545,85 @@
         </Setter>
     </Style>
 
+    <!-- List Item Container Styles for proper spacing and alignment -->
+    <Style x:Key="ListItemContainer" TargetType="ContentView">
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Margin" Value="0" />
+    </Style>
+
+    <Style x:Key="ListItemFrame" TargetType="Frame">
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light=LightGray, Dark=#555555}" />
+        <Setter Property="CornerRadius" Value="8" />
+        <Setter Property="Padding" Value="12" />
+        <Setter Property="Margin" Value="8,4" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource White}, Dark=#2A2A2A}" />
+        <Setter Property="HasShadow" Value="False" />
+    </Style>
+
+    <Style x:Key="ListCollectionView" TargetType="CollectionView">
+        <Setter Property="ItemSizingStrategy" Value="MeasureFirstItem" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="BackgroundColor" Value="Transparent" />
+    </Style>
+
+    <Style x:Key="ListItemContentGrid" TargetType="Grid">
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="Margin" Value="0" />
+        <Setter Property="ColumnSpacing" Value="12" />
+        <Setter Property="RowSpacing" Value="0" />
+    </Style>
+
+    <!-- Delete Button Style - consistent across the app -->
+    <Style x:Key="DeleteButton" TargetType="Button">
+        <Setter Property="Text" Value="✕" />
+        <Setter Property="WidthRequest" Value="36" />
+        <Setter Property="HeightRequest" Value="36" />
+        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#FFE6E6, Dark=#4A2C2C}" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light=#CC0000, Dark=#FF6666}" />
+        <Setter Property="FontSize" Value="16" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="CornerRadius" Value="18" />
+        <Setter Property="BorderColor" Value="{AppThemeBinding Light=#FFCCCC, Dark=#664444}" />
+        <Setter Property="BorderWidth" Value="1" />
+        <Setter Property="Padding" Value="0" />
+        <Setter Property="VerticalOptions" Value="Center" />
+        <Setter Property="HorizontalOptions" Value="Center" />
+    </Style>
+
+    <!-- Nutrition Info Labels -->
+    <Style x:Key="CaloriesLabel" TargetType="Label">
+        <Setter Property="FontSize" Value="12" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light=DarkOrange, Dark=Orange}" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="VerticalOptions" Value="Center" />
+    </Style>
+
+    <Style x:Key="MacroLabel" TargetType="Label">
+        <Setter Property="FontSize" Value="11" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light=Gray, Dark=LightGray}" />
+        <Setter Property="VerticalOptions" Value="Center" />
+    </Style>
+
+    <!-- Main Content Styles -->
+    <Style x:Key="ItemTitleLabel" TargetType="Label">
+        <Setter Property="FontSize" Value="18" />
+        <Setter Property="FontAttributes" Value="Bold" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}" />
+        <Setter Property="VerticalOptions" Value="Start" />
+    </Style>
+
+    <Style x:Key="ItemSubtitleLabel" TargetType="Label">
+        <Setter Property="FontSize" Value="14" />
+        <Setter Property="TextColor" Value="{AppThemeBinding Light=Gray, Dark=LightGray}" />
+        <Setter Property="VerticalOptions" Value="Start" />
+        <Setter Property="Margin" Value="0,2,0,4" />
+    </Style>
+
+    <!-- Nutrition Info Container -->
+    <Style x:Key="NutritionContainer" TargetType="StackLayout">
+        <Setter Property="Orientation" Value="Horizontal" />
+        <Setter Property="Spacing" Value="15" />
+        <Setter Property="Margin" Value="0,4,0,0" />
+    </Style>
+
 </ResourceDictionary>

--- a/FoodbookApp.App/Services/IIngredientService.cs
+++ b/FoodbookApp.App/Services/IIngredientService.cs
@@ -7,4 +7,9 @@ public interface IIngredientService
     Task AddIngredientAsync(Ingredient ingredient);
     Task UpdateIngredientAsync(Ingredient ingredient);
     Task DeleteIngredientAsync(int id);
+    
+    /// <summary>
+    /// Invalidates the ingredients cache to force refresh on next access
+    /// </summary>
+    void InvalidateCache();
 }

--- a/FoodbookApp.App/Services/RecipeService.cs
+++ b/FoodbookApp.App/Services/RecipeService.cs
@@ -13,9 +13,21 @@ namespace Foodbook.Services
             _context = context ?? throw new ArgumentNullException(nameof(context));
         }
 
-        public async Task<List<Recipe>> GetRecipesAsync() => await _context.Recipes.Include(r => r.Ingredients).ToListAsync();
-        public async Task<Recipe?> GetRecipeAsync(int id) => await _context.Recipes.Include(r => r.Ingredients).FirstOrDefaultAsync(r => r.Id == id);
+        // ? KRYTYCZNA OPTYMALIZACJA: AsNoTracking dla odczytu
+        public async Task<List<Recipe>> GetRecipesAsync() => 
+            await _context.Recipes
+                .AsNoTracking() // Eliminuje tracking conflicts
+                .Include(r => r.Ingredients)
+                .ToListAsync();
 
+        // ? KRYTYCZNA OPTYMALIZACJA: AsNoTracking dla pojedynczego odczytu
+        public async Task<Recipe?> GetRecipeAsync(int id) => 
+            await _context.Recipes
+                .AsNoTracking() // Eliminuje tracking conflicts
+                .Include(r => r.Ingredients)
+                .FirstOrDefaultAsync(r => r.Id == id);
+
+        // ? KRYTYCZNA OPTYMALIZACJA: Kontrolowane dodawanie
         public async Task AddRecipeAsync(Recipe recipe)
         {
             if (recipe == null)
@@ -23,25 +35,129 @@ namespace Foodbook.Services
             if (recipe.Ingredients == null)
                 recipe.Ingredients = new List<Ingredient>();
 
-            _context.Recipes.Add(recipe);
-            await _context.SaveChangesAsync();
+            try
+            {
+                // Detach wszystkich sk³adników przed dodaniem
+                foreach (var ingredient in recipe.Ingredients)
+                {
+                    var existingEntry = _context.Entry(ingredient);
+                    if (existingEntry.State != EntityState.Detached)
+                    {
+                        existingEntry.State = EntityState.Detached;
+                    }
+                    
+                    // Reset ID dla nowych sk³adników przepisu
+                    if (ingredient.RecipeId == null)
+                    {
+                        ingredient.Id = 0; // Nowy sk³adnik przepisu
+                    }
+                }
+
+                _context.Recipes.Add(recipe);
+                await _context.SaveChangesAsync();
+                
+                System.Diagnostics.Debug.WriteLine($"? Added recipe: {recipe.Name} with {recipe.Ingredients.Count} ingredients");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"? Error adding recipe: {ex.Message}");
+                
+                // Clear tracking na b³¹d
+                _context.ChangeTracker.Clear();
+                throw;
+            }
         }
 
+        // ? KRYTYCZNA OPTYMALIZACJA: Transakcyjne updatey
         public async Task UpdateRecipeAsync(Recipe recipe)
         {
             if (recipe == null)
                 throw new ArgumentNullException(nameof(recipe));
-            _context.Recipes.Update(recipe);
-            await _context.SaveChangesAsync();
+
+            using var transaction = await _context.Database.BeginTransactionAsync();
+            
+            try
+            {
+                // Pobierz istniej¹cy przepis z sk³adnikami
+                var existingRecipe = await _context.Recipes
+                    .Include(r => r.Ingredients)
+                    .FirstOrDefaultAsync(r => r.Id == recipe.Id);
+
+                if (existingRecipe == null)
+                {
+                    throw new InvalidOperationException($"Recipe with ID {recipe.Id} not found");
+                }
+
+                // Aktualizuj podstawowe w³aœciwoœci przepisu
+                existingRecipe.Name = recipe.Name;
+                existingRecipe.Description = recipe.Description;
+                existingRecipe.Calories = recipe.Calories;
+                existingRecipe.Protein = recipe.Protein;
+                existingRecipe.Fat = recipe.Fat;
+                existingRecipe.Carbs = recipe.Carbs;
+                existingRecipe.IloscPorcji = recipe.IloscPorcji;
+
+                // ? OPTYMALIZACJA: Zarz¹dzanie sk³adnikami bez tracking conflicts
+                
+                // Usuñ wszystkie istniej¹ce sk³adniki przepisu
+                var existingIngredients = existingRecipe.Ingredients.ToList();
+                _context.Ingredients.RemoveRange(existingIngredients);
+
+                // Dodaj nowe sk³adniki
+                foreach (var ingredient in recipe.Ingredients)
+                {
+                    var newIngredient = new Ingredient
+                    {
+                        Name = ingredient.Name,
+                        Quantity = ingredient.Quantity,
+                        Unit = ingredient.Unit,
+                        Calories = ingredient.Calories,
+                        Protein = ingredient.Protein,
+                        Fat = ingredient.Fat,
+                        Carbs = ingredient.Carbs,
+                        RecipeId = recipe.Id
+                    };
+                    
+                    _context.Ingredients.Add(newIngredient);
+                }
+
+                await _context.SaveChangesAsync();
+                await transaction.CommitAsync();
+                
+                System.Diagnostics.Debug.WriteLine($"? Updated recipe: {recipe.Name} with {recipe.Ingredients.Count} ingredients");
+            }
+            catch (Exception ex)
+            {
+                await transaction.RollbackAsync();
+                System.Diagnostics.Debug.WriteLine($"? Error updating recipe: {ex.Message}");
+                
+                // Clear tracking na b³¹d
+                _context.ChangeTracker.Clear();
+                throw;
+            }
         }
 
         public async Task DeleteRecipeAsync(int id)
         {
-            var recipe = await _context.Recipes.FindAsync(id);
-            if (recipe != null)
+            try
             {
-                _context.Recipes.Remove(recipe);
-                await _context.SaveChangesAsync();
+                var recipe = await _context.Recipes
+                    .Include(r => r.Ingredients)
+                    .FirstOrDefaultAsync(r => r.Id == id);
+                    
+                if (recipe != null)
+                {
+                    // EF Core automatycznie usunie sk³adniki dziêki cascade delete
+                    _context.Recipes.Remove(recipe);
+                    await _context.SaveChangesAsync();
+                    
+                    System.Diagnostics.Debug.WriteLine($"? Deleted recipe: {recipe.Name}");
+                }
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"? Error deleting recipe: {ex.Message}");
+                throw;
             }
         }
     }

--- a/FoodbookApp.App/ViewModels/AddRecipeViewModel.cs
+++ b/FoodbookApp.App/ViewModels/AddRecipeViewModel.cs
@@ -195,6 +195,7 @@ namespace Foodbook.ViewModels
                 await ScheduleNutritionalCalculationAsync();
                 ValidateInput();
             };
+
             ValidateInput();
         }
 
@@ -611,7 +612,12 @@ namespace Foodbook.ViewModels
         {
             try
             {
-                return !HasValidationError;
+                // ✅ OPTYMALIZACJA: Bardziej szczegółowa logika CanSave
+                bool isValid = !HasValidationError && !string.IsNullOrWhiteSpace(Name);
+                
+                System.Diagnostics.Debug.WriteLine($"CanSave: {isValid} (HasValidationError: {HasValidationError}, Name: '{Name}')");
+                
+                return isValid;
             }
             catch (Exception ex)
             {
@@ -727,9 +733,14 @@ namespace Foodbook.ViewModels
         {
             try
             {
+                System.Diagnostics.Debug.WriteLine("🔄 SaveRecipeAsync started");
+                
                 ValidateInput();
                 if (HasValidationError)
+                {
+                    System.Diagnostics.Debug.WriteLine($"❌ Validation failed: {ValidationMessage}");
                     return;
+                }
 
                 var recipe = _editingRecipe ?? new Recipe();
                 recipe.Name = Name;
@@ -744,10 +755,18 @@ namespace Foodbook.ViewModels
                 
                 recipe.Ingredients = Ingredients.ToList();
 
+                System.Diagnostics.Debug.WriteLine($"💾 Saving recipe: {recipe.Name} (Edit mode: {_editingRecipe != null})");
+
                 if (_editingRecipe == null)
+                {
                     await _recipeService.AddRecipeAsync(recipe);
+                    System.Diagnostics.Debug.WriteLine("✅ Recipe added successfully");
+                }
                 else
+                {
                     await _recipeService.UpdateRecipeAsync(recipe);
+                    System.Diagnostics.Debug.WriteLine("✅ Recipe updated successfully");
+                }
 
                 // Reset form po udanym zapisie tylko w trybie dodawania
                 if (_editingRecipe == null)
@@ -762,15 +781,18 @@ namespace Foodbook.ViewModels
                     ImportUrl = string.Empty;
                     ImportStatus = string.Empty;
                     UseCalculatedValues = true;
+                    
+                    System.Diagnostics.Debug.WriteLine("🔄 Form reset after successful add");
                 }
 
                 // Zawsze wróć do grida po zapisie
+                System.Diagnostics.Debug.WriteLine("🔙 Navigating back");
                 await Shell.Current.GoToAsync("..");
             }
             catch (Exception ex)
             {
                 ValidationMessage = $"Błąd zapisywania: {ex.Message}";
-                System.Diagnostics.Debug.WriteLine($"Error in SaveRecipeAsync: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"❌ Error in SaveRecipeAsync: {ex.Message}");
             }
         }
         

--- a/FoodbookApp.App/ViewModels/IngredientsViewModel.cs
+++ b/FoodbookApp.App/ViewModels/IngredientsViewModel.cs
@@ -127,52 +127,61 @@ public class IngredientsViewModel : INotifyPropertyChanged
 
             BulkVerificationStatus = $"Weryfikujê sk³adniki: 0/{totalCount}";
 
-            for (int i = 0; i < Ingredients.Count; i++)
+            // ? OPTYMALIZACJA: Batch processing z throttling
+            const int batchSize = 5; // Mniejsze batche dla API
+            for (int i = 0; i < Ingredients.Count; i += batchSize)
             {
-                var ingredient = Ingredients[i];
+                var batch = Ingredients.Skip(i).Take(batchSize).ToList();
                 
-                try
+                // Process batch
+                foreach (var ingredient in batch)
                 {
-                    BulkVerificationStatus = $"Weryfikujê sk³adniki: {i + 1}/{totalCount} - {ingredient.Name}";
-
-                    // Skopiuj sk³adnik do weryfikacji
-                    var tempIngredient = new Ingredient
+                    try
                     {
-                        Id = ingredient.Id,
-                        Name = ingredient.Name,
-                        Quantity = ingredient.Quantity,
-                        Unit = ingredient.Unit,
-                        Calories = ingredient.Calories,
-                        Protein = ingredient.Protein,
-                        Fat = ingredient.Fat,
-                        Carbs = ingredient.Carbs,
-                        RecipeId = ingredient.RecipeId
-                    };
+                        BulkVerificationStatus = $"Weryfikujê sk³adniki: {i + 1}/{totalCount} - {ingredient.Name}";
 
-                    // Weryfikuj z OpenFoodFacts
-                    bool wasUpdated = await SeedData.UpdateIngredientWithOpenFoodFactsAsync(tempIngredient);
+                        // Skopiuj sk³adnik do weryfikacji
+                        var tempIngredient = new Ingredient
+                        {
+                            Id = ingredient.Id,
+                            Name = ingredient.Name,
+                            Quantity = ingredient.Quantity,
+                            Unit = ingredient.Unit,
+                            Calories = ingredient.Calories,
+                            Protein = ingredient.Protein,
+                            Fat = ingredient.Fat,
+                            Carbs = ingredient.Carbs,
+                            RecipeId = ingredient.RecipeId
+                        };
 
-                    if (wasUpdated)
-                    {
-                        // Aktualizuj sk³adnik w bazie danych
-                        ingredient.Calories = tempIngredient.Calories;
-                        ingredient.Protein = tempIngredient.Protein;
-                        ingredient.Fat = tempIngredient.Fat;
-                        ingredient.Carbs = tempIngredient.Carbs;
+                        // Weryfikuj z OpenFoodFacts
+                        bool wasUpdated = await SeedData.UpdateIngredientWithOpenFoodFactsAsync(tempIngredient);
 
-                        await _service.UpdateIngredientAsync(ingredient);
-                        updatedCount++;
-                        
-                        System.Diagnostics.Debug.WriteLine($"? Zaktualizowano: {ingredient.Name}");
+                        if (wasUpdated)
+                        {
+                            // Aktualizuj sk³adnik w bazie danych
+                            ingredient.Calories = tempIngredient.Calories;
+                            ingredient.Protein = tempIngredient.Protein;
+                            ingredient.Fat = tempIngredient.Fat;
+                            ingredient.Carbs = tempIngredient.Carbs;
+
+                            await _service.UpdateIngredientAsync(ingredient);
+                            updatedCount++;
+                            
+                            System.Diagnostics.Debug.WriteLine($"? Zaktualizowano: {ingredient.Name}");
+                        }
                     }
-
-                    // Ma³e opóŸnienie aby nie przeci¹¿yæ API
-                    await Task.Delay(200);
+                    catch (Exception ex)
+                    {
+                        failedCount++;
+                        System.Diagnostics.Debug.WriteLine($"? B³¹d weryfikacji {ingredient.Name}: {ex.Message}");
+                    }
                 }
-                catch (Exception ex)
+
+                // ? OPTYMALIZACJA: Throttling miêdzy batchami
+                if (i + batchSize < Ingredients.Count)
                 {
-                    failedCount++;
-                    System.Diagnostics.Debug.WriteLine($"? B³¹d weryfikacji {ingredient.Name}: {ex.Message}");
+                    await Task.Delay(1000); // 1 sekunda pauzy miêdzy batchami
                 }
             }
 

--- a/FoodbookApp.App/ViewModels/IngredientsViewModel.cs
+++ b/FoodbookApp.App/ViewModels/IngredientsViewModel.cs
@@ -88,6 +88,7 @@ public class IngredientsViewModel : INotifyPropertyChanged
     public ICommand DeleteCommand { get; }
     public ICommand RefreshCommand { get; }
     public ICommand BulkVerifyCommand { get; } // Nowa komenda
+    public ICommand ClearSearchCommand { get; } // Nowa komenda do czyszczenia wyszukiwania
 
     public IngredientsViewModel(IIngredientService service)
     {
@@ -101,6 +102,7 @@ public class IngredientsViewModel : INotifyPropertyChanged
         DeleteCommand = new Command<Ingredient>(async ing => await DeleteIngredientAsync(ing));
         RefreshCommand = new Command(async () => await ReloadAsync());
         BulkVerifyCommand = new Command(async () => await BulkVerifyIngredientsAsync(), () => !IsBulkVerifying && Ingredients.Count > 0);
+        ClearSearchCommand = new Command(() => SearchText = string.Empty); // Komenda do czyszczenia wyszukiwania
     }
 
     /// <summary>

--- a/FoodbookApp.App/ViewModels/RecipeViewModel.cs
+++ b/FoodbookApp.App/ViewModels/RecipeViewModel.cs
@@ -62,6 +62,7 @@ namespace Foodbook.ViewModels
         public ICommand EditRecipeCommand { get; }
         public ICommand DeleteRecipeCommand { get; }
         public ICommand RefreshCommand { get; }
+        public ICommand ClearSearchCommand { get; } // Nowa komenda do czyszczenia wyszukiwania
 
         public RecipeViewModel(IRecipeService recipeService, IIngredientService ingredientService)
         {
@@ -75,6 +76,7 @@ namespace Foodbook.ViewModels
             });
             DeleteRecipeCommand = new Command<Recipe>(async r => await DeleteRecipeAsync(r));
             RefreshCommand = new Command(async () => await ReloadAsync());
+            ClearSearchCommand = new Command(() => SearchText = string.Empty);
         }
 
         public async Task LoadRecipesAsync()
@@ -258,6 +260,13 @@ namespace Foodbook.ViewModels
                 System.Diagnostics.Debug.WriteLine($"Error deleting recipe: {ex.Message}");
                 // Could show user-friendly error message here
             }
+        }
+
+        private void ExecuteClearSearchCommand()
+        {
+            SearchText = string.Empty;
+            // Optionally, reload or reset the recipe list here if needed
+            // await LoadRecipesAsync();
         }
 
         public event PropertyChangedEventHandler PropertyChanged;

--- a/FoodbookApp.App/Views/AddRecipePage.xaml
+++ b/FoodbookApp.App/Views/AddRecipePage.xaml
@@ -448,6 +448,7 @@
                 <!-- Action Buttons - Always visible at bottom -->
                 <StackLayout Spacing="10" Margin="0,20,0,0">
                     <Button Command="{Binding SaveRecipeCommand}"
+                            Text="{Binding SaveButtonText}"
                             HeightRequest="50"
                             FontSize="16"
                             FontAttributes="Bold">

--- a/FoodbookApp.App/Views/AddRecipePage.xaml
+++ b/FoodbookApp.App/Views/AddRecipePage.xaml
@@ -18,47 +18,75 @@
     
     <Grid RowDefinitions="Auto,*">
         
-        <!-- Tab Bar - Wysokość minimum 5% ekranu -->
+        <!-- Tab Bar - Modern style with underline indicators -->
         <Grid Grid.Row="0" 
+              RowDefinitions="*,3"
               ColumnDefinitions="*,*,*" 
               HeightRequest="{OnPlatform Default=60, iOS=70}"
-              BackgroundColor="{AppThemeBinding Light=#F0F0F0, Dark=#2D2D30}">
+              BackgroundColor="{AppThemeBinding Light=White, Dark=#2D2D30}">
             
+            <!-- Tab Buttons -->
             <!-- Tab 1: Nazwa i opis -->
-            <Button Grid.Column="0"
+            <Button Grid.Row="0" Grid.Column="0"
                     Text="{loc:Translate Resource=AddRecipePageResources, Key=BasicInfoTab}"
                     Command="{Binding SelectTabCommand}"
                     CommandParameter="0"
-                    BackgroundColor="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}}"
+                    BackgroundColor="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBackground'}"
                     TextColor="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Text'}"
-                    FontSize="12"
+                    FontSize="14"
                     FontAttributes="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Bold'}"
                     CornerRadius="0"
-                    BorderWidth="0" />
+                    BorderWidth="0"
+                    Padding="0" />
             
             <!-- Tab 2: Składniki -->
-            <Button Grid.Column="1"
+            <Button Grid.Row="0" Grid.Column="1"
                     Text="{loc:Translate Resource=AddRecipePageResources, Key=IngredientsTab}"
                     Command="{Binding SelectTabCommand}"
                     CommandParameter="1"
-                    BackgroundColor="{Binding IsIngredientsTabSelected, Converter={StaticResource BoolToColorConverter}}"
+                    BackgroundColor="{Binding IsIngredientsTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBackground'}"
                     TextColor="{Binding IsIngredientsTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Text'}"
-                    FontSize="12"
+                    FontSize="14"
                     FontAttributes="{Binding IsIngredientsTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Bold'}"
                     CornerRadius="0"
-                    BorderWidth="0" />
+                    BorderWidth="0"
+                    Padding="0" />
             
             <!-- Tab 3: Wartości odżywcze -->
-            <Button Grid.Column="2"
+            <Button Grid.Row="0" Grid.Column="2"
                     Text="{loc:Translate Resource=AddRecipePageResources, Key=NutritionTab}"
                     Command="{Binding SelectTabCommand}"
                     CommandParameter="2"
-                    BackgroundColor="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}}"
+                    BackgroundColor="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBackground'}"
                     TextColor="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Text'}"
-                    FontSize="12"
+                    FontSize="14"
                     FontAttributes="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Bold'}"
                     CornerRadius="0"
-                    BorderWidth="0" />
+                    BorderWidth="0"
+                    Padding="0" />
+            
+            <!-- Underline Indicators -->
+            <BoxView Grid.Row="1" Grid.Column="0"
+                     BackgroundColor="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBorder'}"
+                     HeightRequest="3"
+                     HorizontalOptions="FillAndExpand" />
+            
+            <BoxView Grid.Row="1" Grid.Column="1"
+                     BackgroundColor="{Binding IsIngredientsTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBorder'}"
+                     HeightRequest="3"
+                     HorizontalOptions="FillAndExpand" />
+            
+            <BoxView Grid.Row="1" Grid.Column="2"
+                     BackgroundColor="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBorder'}"
+                     HeightRequest="3"
+                     HorizontalOptions="FillAndExpand" />
+            
+            <!-- Separator line under tabs -->
+            <BoxView Grid.Row="1" Grid.ColumnSpan="3"
+                     BackgroundColor="{AppThemeBinding Light=#E1E1E1, Dark=#404040}"
+                     HeightRequest="1"
+                     HorizontalOptions="FillAndExpand"
+                     VerticalOptions="End" />
         </Grid>
         
         <!-- Content Area -->

--- a/FoodbookApp.App/Views/IngredientFormPage.xaml
+++ b/FoodbookApp.App/Views/IngredientFormPage.xaml
@@ -17,35 +17,57 @@
     
     <Grid RowDefinitions="Auto,*">
         
-        <!-- Tab Bar -->
+        <!-- Tab Bar - Modern style with underline indicators -->
         <Grid Grid.Row="0" 
+              RowDefinitions="*,3"
               ColumnDefinitions="*,*" 
               HeightRequest="{OnPlatform Default=60, iOS=70}"
-              BackgroundColor="{AppThemeBinding Light=#F0F0F0, Dark=#2D2D30}">
+              BackgroundColor="{AppThemeBinding Light=White, Dark=#2D2D30}">
             
+            <!-- Tab Buttons -->
             <!-- Tab 1: Informacje podstawowe -->
-            <Button Grid.Column="0"
+            <Button Grid.Row="0" Grid.Column="0"
                     Text="{loc:Translate Resource=IngredientFormPageResources, Key=BasicInfoTab}"
                     Command="{Binding SelectTabCommand}"
                     CommandParameter="0"
-                    BackgroundColor="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}}"
+                    BackgroundColor="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBackground'}"
                     TextColor="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Text'}"
-                    FontSize="12"
+                    FontSize="14"
                     FontAttributes="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Bold'}"
                     CornerRadius="0"
-                    BorderWidth="0" />
+                    BorderWidth="0"
+                    Padding="0" />
             
             <!-- Tab 2: Wartości odżywcze -->
-            <Button Grid.Column="1"
+            <Button Grid.Row="0" Grid.Column="1"
                     Text="{loc:Translate Resource=IngredientFormPageResources, Key=NutritionTab}"
                     Command="{Binding SelectTabCommand}"
                     CommandParameter="1"
-                    BackgroundColor="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}}"
+                    BackgroundColor="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBackground'}"
                     TextColor="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Text'}"
-                    FontSize="12"
+                    FontSize="14"
                     FontAttributes="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='Bold'}"
                     CornerRadius="0"
-                    BorderWidth="0" />
+                    BorderWidth="0"
+                    Padding="0" />
+            
+            <!-- Underline Indicators -->
+            <BoxView Grid.Row="1" Grid.Column="0"
+                     BackgroundColor="{Binding IsBasicInfoTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBorder'}"
+                     HeightRequest="3"
+                     HorizontalOptions="FillAndExpand" />
+            
+            <BoxView Grid.Row="1" Grid.Column="1"
+                     BackgroundColor="{Binding IsNutritionTabSelected, Converter={StaticResource BoolToColorConverter}, ConverterParameter='TabBorder'}"
+                     HeightRequest="3"
+                     HorizontalOptions="FillAndExpand" />
+            
+            <!-- Separator line under tabs -->
+            <BoxView Grid.Row="1" Grid.ColumnSpan="2"
+                     BackgroundColor="{AppThemeBinding Light=#E1E1E1, Dark=#404040}"
+                     HeightRequest="1"
+                     HorizontalOptions="FillAndExpand"
+                     VerticalOptions="End" />
         </Grid>
         
         <!-- Content Area -->

--- a/FoodbookApp.App/Views/IngredientsPage.xaml
+++ b/FoodbookApp.App/Views/IngredientsPage.xaml
@@ -25,12 +25,31 @@
                           Color="{AppThemeBinding Light=Black, Dark=White}"
                           Margin="10" />
 
-        <!-- Search bar -->
-        <SearchBar Grid.Row="1"
-                   Text="{Binding SearchText}"
-                   Placeholder="{loc:Translate Resource=IngredientsPageResources, Key=SearchPlaceholder}"
-                   Margin="10,0"
-                   IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
+        <!-- Modern Search Bar -->
+        <Frame Grid.Row="1"
+               Style="{StaticResource ModernSearchBarFrame}"
+               Margin="15,10"
+               IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
+            <Grid ColumnDefinitions="50,*,Auto" VerticalOptions="Center">
+                <!-- Search Icon -->
+                <Label Grid.Column="0"
+                       Style="{StaticResource SearchIconLabel}" />
+                
+                <!-- Search Entry -->
+                <Entry Grid.Column="1"
+                       Style="{StaticResource ModernSearchEntry}"
+                       Text="{Binding SearchText}"
+                       Placeholder="{loc:Translate Resource=IngredientsPageResources, Key=SearchPlaceholder}"
+                       Margin="0,0,15,0" />
+                
+                <!-- Clear Button -->
+                <Button Grid.Column="2"
+                        Style="{StaticResource ClearSearchButton}"
+                        Command="{Binding ClearSearchCommand}"
+                        IsVisible="{Binding SearchText, Converter={StaticResource StringToBoolConverter}}"
+                        Margin="0,0,10,0" />
+            </Grid>
+        </Frame>
 
         <!-- Content -->
         <RefreshView Grid.Row="2" 

--- a/FoodbookApp.App/Views/IngredientsPage.xaml
+++ b/FoodbookApp.App/Views/IngredientsPage.xaml
@@ -58,92 +58,75 @@
                          IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
                 
                 <CollectionView ItemsSource="{Binding Ingredients}"
-                                ItemSizingStrategy="MeasureFirstItem"
-                                RemainingItemsThreshold="10"
-                                Margin="10,0">
+                                Style="{StaticResource ListCollectionView}"
+                                RemainingItemsThreshold="10">
                     
                     <CollectionView.ItemsLayout>
-                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="5" />
+                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="0" />
                     </CollectionView.ItemsLayout>
                     
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="models:Ingredient">
-                            <!-- Ujednolicony layout zgodny z PlannerPage -->
-                            <Frame BorderColor="LightGray" Padding="10" Margin="0,3">
-                                <Frame.GestureRecognizers>
-                                    <TapGestureRecognizer Command="{Binding BindingContext.EditCommand, Source={x:Reference ThisPage}}" 
-                                                          CommandParameter="{Binding .}" />
-                                </Frame.GestureRecognizers>
-                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-                                    <!-- Kolumna z treścią składnika -->
-                                    <StackLayout Grid.Column="0">
-                                        <Label Text="{Binding Name}" 
-                                               FontSize="18" 
-                                               FontAttributes="Bold" />
-                                        <Label FontSize="14" 
-                                               TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                            <Label.Text>
-                                                <MultiBinding StringFormat="{}{0:F1} {1}">
-                                                    <Binding Path="Quantity" />
-                                                    <Binding Path="Unit" />
-                                                </MultiBinding>
-                                            </Label.Text>
-                                        </Label>
-                                        
-                                        <!-- Informacje odżywcze w jednej linii -->
-                                        <StackLayout Orientation="Horizontal" Spacing="15" Margin="0,2,0,0">
-                                            <Label FontSize="12" 
-                                                   TextColor="{AppThemeBinding Light=DarkOrange, Dark=Orange}"
-                                                   FontAttributes="Bold">
+                            <ContentView Style="{StaticResource ListItemContainer}">
+                                <Frame Style="{StaticResource ListItemFrame}">
+                                    <Frame.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding BindingContext.EditCommand, Source={x:Reference ThisPage}}" 
+                                                              CommandParameter="{Binding .}" />
+                                    </Frame.GestureRecognizers>
+                                    <Grid Style="{StaticResource ListItemContentGrid}" ColumnDefinitions="*,Auto">
+                                        <!-- Ingredient content column -->
+                                        <StackLayout Grid.Column="0" Spacing="2">
+                                            <Label Text="{Binding Name}" Style="{StaticResource ItemTitleLabel}" />
+                                            <Label Style="{StaticResource ItemSubtitleLabel}">
                                                 <Label.Text>
-                                                    <MultiBinding StringFormat="{}{0:F0} kcal">
-                                                        <Binding Path="Calories" />
+                                                    <MultiBinding StringFormat="{}{0:F1} {1}">
+                                                        <Binding Path="Quantity" />
+                                                        <Binding Path="Unit" />
                                                     </MultiBinding>
                                                 </Label.Text>
                                             </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="P: {0:F1}g">
-                                                        <Binding Path="Protein" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="F: {0:F1}g">
-                                                        <Binding Path="Fat" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="C: {0:F1}g">
-                                                        <Binding Path="Carbs" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
+                                            
+                                            <!-- Nutrition info in horizontal layout -->
+                                            <StackLayout Style="{StaticResource NutritionContainer}">
+                                                <Label Style="{StaticResource CaloriesLabel}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="{}{0:F0} kcal">
+                                                            <Binding Path="Calories" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label Style="{StaticResource MacroLabel}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="P: {0:F1}g">
+                                                            <Binding Path="Protein" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label Style="{StaticResource MacroLabel}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="F: {0:F1}g">
+                                                            <Binding Path="Fat" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label Style="{StaticResource MacroLabel}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="C: {0:F1}g">
+                                                            <Binding Path="Carbs" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                            </StackLayout>
                                         </StackLayout>
-                                    </StackLayout>
-                                    
-                                    <!-- Przycisk usuwania - zgodny ze stylem ShoppingListDetailPage -->
-                                    <Button Grid.Column="1" 
-                                            Text="✕" 
-                                            Command="{Binding BindingContext.DeleteCommand, Source={x:Reference ThisPage}}" 
-                                            CommandParameter="{Binding .}" 
-                                            WidthRequest="35" 
-                                            HeightRequest="35"
-                                            BackgroundColor="{AppThemeBinding Light=#FFE6E6, Dark=#4A2C2C}"
-                                            TextColor="{AppThemeBinding Light=#CC0000, Dark=#FF6666}"
-                                            FontSize="16"
-                                            CornerRadius="17"
-                                            BorderColor="{AppThemeBinding Light=#FFCCCC, Dark=#664444}"
-                                            BorderWidth="1"
-                                            VerticalOptions="Center" />
-                                </Grid>
-                            </Frame>
+                                        
+                                        <!-- Delete button -->
+                                        <Button Grid.Column="1" 
+                                                Style="{StaticResource DeleteButton}"
+                                                Command="{Binding BindingContext.DeleteCommand, Source={x:Reference ThisPage}}" 
+                                                CommandParameter="{Binding .}" />
+                                    </Grid>
+                                </Frame>
+                            </ContentView>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                     

--- a/FoodbookApp.App/Views/IngredientsPage.xaml
+++ b/FoodbookApp.App/Views/IngredientsPage.xaml
@@ -52,23 +52,12 @@
         </Frame>
 
         <!-- Content -->
-        <RefreshView Grid.Row="2" 
-                     IsRefreshing="{Binding IsRefreshing}" 
-                     Command="{Binding RefreshCommand}"
-                     IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
-            
-            <Grid RowDefinitions="Auto,*">
-                <!-- Action Buttons Section - Simplified to single button -->
-                <Grid Grid.Row="0" 
-                      Margin="10">
-                    <Button Command="{Binding AddCommand}"
-                            TextColor="White"
-                            HeightRequest="45"
-                            Text="{loc:Translate Resource=IngredientsPageResources, Key=AddButton}" />
-                </Grid>
-
-                <CollectionView Grid.Row="1"
-                                ItemsSource="{Binding Ingredients}"
+        <Grid Grid.Row="2">
+            <RefreshView IsRefreshing="{Binding IsRefreshing}" 
+                         Command="{Binding RefreshCommand}"
+                         IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
+                
+                <CollectionView ItemsSource="{Binding Ingredients}"
                                 ItemSizingStrategy="MeasureFirstItem"
                                 RemainingItemsThreshold="10"
                                 Margin="10,0">
@@ -173,8 +162,13 @@
                     </CollectionView.EmptyView>
                     
                 </CollectionView>
-            </Grid>
-        </RefreshView>
+            </RefreshView>
+            
+            <!-- Floating Action Button -->
+            <Button Style="{StaticResource FloatingActionButton}"
+                    Command="{Binding AddCommand}"
+                    IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
+        </Grid>
     </Grid>
 
 </ContentPage>

--- a/FoodbookApp.App/Views/RecipesPage.xaml
+++ b/FoodbookApp.App/Views/RecipesPage.xaml
@@ -24,12 +24,31 @@
                           Color="{AppThemeBinding Light=Black, Dark=White}"
                           Margin="10" />
 
-        <!-- Search bar -->
-        <SearchBar Grid.Row="1"
-                   Text="{Binding SearchText}"
-                   Placeholder="{loc:Translate Resource=RecipesPageResources, Key=SearchPlaceholder}"
-                   Margin="10,0"
-                   IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
+        <!-- Modern Search Bar -->
+        <Frame Grid.Row="1"
+               Style="{StaticResource ModernSearchBarFrame}"
+               Margin="15,10"
+               IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
+            <Grid ColumnDefinitions="50,*,Auto" VerticalOptions="Center">
+                <!-- Search Icon -->
+                <Label Grid.Column="0"
+                       Style="{StaticResource SearchIconLabel}" />
+                
+                <!-- Search Entry -->
+                <Entry Grid.Column="1"
+                       Style="{StaticResource ModernSearchEntry}"
+                       Text="{Binding SearchText}"
+                       Placeholder="{loc:Translate Resource=RecipesPageResources, Key=SearchPlaceholder}"
+                       Margin="0,0,15,0" />
+                
+                <!-- Clear Button -->
+                <Button Grid.Column="2"
+                        Style="{StaticResource ClearSearchButton}"
+                        Command="{Binding ClearSearchCommand}"
+                        IsVisible="{Binding SearchText, Converter={StaticResource StringToBoolConverter}}"
+                        Margin="0,0,10,0" />
+            </Grid>
+        </Frame>
 
         <!-- Content -->
         <RefreshView Grid.Row="2" 

--- a/FoodbookApp.App/Views/RecipesPage.xaml
+++ b/FoodbookApp.App/Views/RecipesPage.xaml
@@ -51,22 +51,12 @@
         </Frame>
 
         <!-- Content -->
-        <RefreshView Grid.Row="2" 
-                     IsRefreshing="{Binding IsRefreshing}" 
-                     Command="{Binding RefreshCommand}"
-                     IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
-            
-            <Grid RowDefinitions="Auto,*">
-                <!-- Action Buttons Section -->
-                <Grid Grid.Row="0" 
-                      Margin="10">
-                    <Button Clicked="OnAddRecipeClicked"
-                            HeightRequest="45"
-                            Text="{loc:Translate Resource=RecipesPageResources, Key=AddButton}" />
-                </Grid>
-
-                <CollectionView Grid.Row="1"
-                                x:Name="RecipesCollectionView" 
+        <Grid Grid.Row="2">
+            <RefreshView IsRefreshing="{Binding IsRefreshing}" 
+                         Command="{Binding RefreshCommand}"
+                         IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
+                
+                <CollectionView x:Name="RecipesCollectionView" 
                                 ItemsSource="{Binding Recipes}"
                                 ItemSizingStrategy="MeasureFirstItem"
                                 RemainingItemsThreshold="10"
@@ -160,8 +150,13 @@
                     </CollectionView.EmptyView>
                     
                 </CollectionView>
-            </Grid>
-        </RefreshView>
+            </RefreshView>
+            
+            <!-- Floating Action Button -->
+            <Button Style="{StaticResource FloatingActionButton}"
+                    Command="{Binding AddRecipeCommand}"
+                    IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}" />
+        </Grid>
     </Grid>
 
 </ContentPage>

--- a/FoodbookApp.App/Views/RecipesPage.xaml
+++ b/FoodbookApp.App/Views/RecipesPage.xaml
@@ -13,6 +13,7 @@
     
     <ContentPage.Resources>
         <converters:InvertedBoolConverter x:Key="InvertedBoolConverter" />
+        <converters:StringToBoolConverter x:Key="StringToBoolConverter" />
     </ContentPage.Resources>
 
     <Grid RowDefinitions="Auto,Auto,*">
@@ -56,101 +57,99 @@
                          Command="{Binding RefreshCommand}"
                          IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
                 
-                <VerticalStackLayout Padding="15,0" Spacing="0">
-                    <CollectionView x:Name="RecipesCollectionView" 
-                                    ItemsSource="{Binding Recipes}"
-                                    ItemSizingStrategy="MeasureFirstItem"
-                                    RemainingItemsThreshold="10">
-                        
-                        <CollectionView.ItemsLayout>
-                            <LinearItemsLayout Orientation="Vertical" ItemSpacing="5" />
-                        </CollectionView.ItemsLayout>
-                        
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="models:Recipe">
-                                <Frame BorderColor="LightGray" Padding="10" Margin="0,3">
-                                    <Frame.GestureRecognizers>
-                                        <TapGestureRecognizer Command="{Binding BindingContext.EditRecipeCommand, Source={x:Reference ThisPage}}" 
-                                                              CommandParameter="{Binding .}" />
-                                    </Frame.GestureRecognizers>
-                                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-                                        <!-- Kolumna z treścią przepisu -->
-                                        <VerticalStackLayout Grid.Column="0">
-                                            <Label Text="{Binding Name}" FontAttributes="Bold" FontSize="18"/>
-                                            
-                                            <!-- Informacje odżywcze w jednej linii -->
-                                            <StackLayout Orientation="Horizontal" Spacing="15" Margin="0,5,0,0">
-                                                <Label FontSize="12" 
-                                                       TextColor="{AppThemeBinding Light=DarkOrange, Dark=Orange}"
-                                                       FontAttributes="Bold">
-                                                    <Label.Text>
-                                                        <MultiBinding StringFormat="{}{0:F0} kcal">
-                                                            <Binding Path="Calories" />
-                                                        </MultiBinding>
-                                                    </Label.Text>
-                                                </Label>
-                                                <Label FontSize="11" 
-                                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                    <Label.Text>
-                                                        <MultiBinding StringFormat="P: {0:F1}g">
-                                                            <Binding Path="Protein" />
-                                                        </MultiBinding>
-                                                    </Label.Text>
-                                                </Label>
-                                                <Label FontSize="11" 
-                                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                    <Label.Text>
-                                                        <MultiBinding StringFormat="F: {0:F1}g">
-                                                            <Binding Path="Fat" />
-                                                        </MultiBinding>
-                                                    </Label.Text>
-                                                </Label>
-                                                <Label FontSize="11" 
-                                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                    <Label.Text>
-                                                        <MultiBinding StringFormat="C: {0:F1}g">
-                                                            <Binding Path="Carbs" />
-                                                        </MultiBinding>
-                                                    </Label.Text>
-                                                </Label>
-                                            </StackLayout>
-                                        </VerticalStackLayout>
+                <CollectionView ItemsSource="{Binding Recipes}"
+                                ItemSizingStrategy="MeasureFirstItem"
+                                RemainingItemsThreshold="10"
+                                Margin="10,0">
+                    
+                    <CollectionView.ItemsLayout>
+                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="5" />
+                    </CollectionView.ItemsLayout>
+                    
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:Recipe">
+                            <Frame BorderColor="LightGray" Padding="10" Margin="0,3">
+                                <Frame.GestureRecognizers>
+                                    <TapGestureRecognizer Command="{Binding BindingContext.EditRecipeCommand, Source={x:Reference ThisPage}}" 
+                                                          CommandParameter="{Binding .}" />
+                                </Frame.GestureRecognizers>
+                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                    <!-- Kolumna z treścią przepisu -->
+                                    <StackLayout Grid.Column="0">
+                                        <Label Text="{Binding Name}" FontAttributes="Bold" FontSize="18"/>
                                         
-                                        <!-- Przycisk usuwania - zgodny ze stylem ShoppingListDetailPage -->
-                                        <Button Grid.Column="1" 
-                                                Text="✕" 
-                                                Command="{Binding BindingContext.DeleteRecipeCommand, Source={x:Reference ThisPage}}" 
-                                                CommandParameter="{Binding .}" 
-                                                WidthRequest="35" 
-                                                HeightRequest="35"
-                                                BackgroundColor="{AppThemeBinding Light=#FFE6E6, Dark=#4A2C2C}"
-                                                TextColor="{AppThemeBinding Light=#CC0000, Dark=#FF6666}"
-                                                FontSize="16"
-                                                CornerRadius="17"
-                                                BorderColor="{AppThemeBinding Light=#FFCCCC, Dark=#664444}"
-                                                BorderWidth="1"
-                                                VerticalOptions="Center" />
-                                    </Grid>
-                                </Frame>
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                        
-                        <CollectionView.EmptyView>
-                            <StackLayout HorizontalOptions="Center" VerticalOptions="Center" Padding="20">
-                                <Label Text="{loc:Translate Resource=RecipesPageResources, Key=EmptyTitle}"
-                                       FontSize="18"
-                                       HorizontalOptions="Center"
-                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}" />
-                                <Label Text="{loc:Translate Resource=RecipesPageResources, Key=EmptyHint}"
-                                       FontSize="14"
-                                       HorizontalOptions="Center"
-                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"
-                                       Margin="0,10,0,0" />
-                            </StackLayout>
-                        </CollectionView.EmptyView>
-                        
-                    </CollectionView>
-                </VerticalStackLayout>
+                                        <!-- Informacje odżywcze w jednej linii -->
+                                        <StackLayout Orientation="Horizontal" Spacing="15" Margin="0,5,0,0">
+                                            <Label FontSize="12" 
+                                                   TextColor="{AppThemeBinding Light=DarkOrange, Dark=Orange}"
+                                                   FontAttributes="Bold">
+                                                <Label.Text>
+                                                    <MultiBinding StringFormat="{}{0:F0} kcal">
+                                                        <Binding Path="Calories" />
+                                                    </MultiBinding>
+                                                </Label.Text>
+                                            </Label>
+                                            <Label FontSize="11" 
+                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
+                                                <Label.Text>
+                                                    <MultiBinding StringFormat="P: {0:F1}g">
+                                                        <Binding Path="Protein" />
+                                                    </MultiBinding>
+                                                </Label.Text>
+                                            </Label>
+                                            <Label FontSize="11" 
+                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
+                                                <Label.Text>
+                                                    <MultiBinding StringFormat="F: {0:F1}g">
+                                                        <Binding Path="Fat" />
+                                                    </MultiBinding>
+                                                </Label.Text>
+                                            </Label>
+                                            <Label FontSize="11" 
+                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
+                                                <Label.Text>
+                                                    <MultiBinding StringFormat="C: {0:F1}g">
+                                                        <Binding Path="Carbs" />
+                                                    </MultiBinding>
+                                                </Label.Text>
+                                            </Label>
+                                        </StackLayout>
+                                    </StackLayout>
+                                    
+                                    <!-- Przycisk usuwania - zgodny ze stylem ShoppingListDetailPage -->
+                                    <Button Grid.Column="1" 
+                                            Text="✕" 
+                                            Command="{Binding BindingContext.DeleteRecipeCommand, Source={x:Reference ThisPage}}" 
+                                            CommandParameter="{Binding .}" 
+                                            WidthRequest="35" 
+                                            HeightRequest="35"
+                                            BackgroundColor="{AppThemeBinding Light=#FFE6E6, Dark=#4A2C2C}"
+                                            TextColor="{AppThemeBinding Light=#CC0000, Dark=#FF6666}"
+                                            FontSize="16"
+                                            CornerRadius="17"
+                                            BorderColor="{AppThemeBinding Light=#FFCCCC, Dark=#664444}"
+                                            BorderWidth="1"
+                                            VerticalOptions="Center" />
+                                </Grid>
+                            </Frame>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                    
+                    <CollectionView.EmptyView>
+                        <StackLayout HorizontalOptions="Center" VerticalOptions="Center" Padding="20">
+                            <Label Text="{loc:Translate Resource=RecipesPageResources, Key=EmptyTitle}"
+                                   FontSize="18"
+                                   HorizontalOptions="Center"
+                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}" />
+                            <Label Text="{loc:Translate Resource=RecipesPageResources, Key=EmptyHint}"
+                                   FontSize="14"
+                                   HorizontalOptions="Center"
+                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"
+                                   Margin="0,10,0,0" />
+                        </StackLayout>
+                    </CollectionView.EmptyView>
+                    
+                </CollectionView>
             </RefreshView>
             
             <!-- Floating Action Button -->

--- a/FoodbookApp.App/Views/RecipesPage.xaml
+++ b/FoodbookApp.App/Views/RecipesPage.xaml
@@ -56,100 +56,101 @@
                          Command="{Binding RefreshCommand}"
                          IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
                 
-                <CollectionView x:Name="RecipesCollectionView" 
-                                ItemsSource="{Binding Recipes}"
-                                ItemSizingStrategy="MeasureFirstItem"
-                                RemainingItemsThreshold="10"
-                                Margin="10,0">
-                    
-                    <CollectionView.ItemsLayout>
-                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="5" />
-                    </CollectionView.ItemsLayout>
-                    
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="models:Recipe">
-                            <Frame BorderColor="LightGray" Padding="10" Margin="0,3">
-                                <Frame.GestureRecognizers>
-                                    <TapGestureRecognizer Command="{Binding BindingContext.EditRecipeCommand, Source={x:Reference ThisPage}}" 
-                                                          CommandParameter="{Binding .}" />
-                                </Frame.GestureRecognizers>
-                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-                                    <!-- Kolumna z treścią przepisu -->
-                                    <VerticalStackLayout Grid.Column="0">
-                                        <Label Text="{Binding Name}" FontAttributes="Bold" FontSize="18"/>
+                <VerticalStackLayout Padding="15,0" Spacing="0">
+                    <CollectionView x:Name="RecipesCollectionView" 
+                                    ItemsSource="{Binding Recipes}"
+                                    ItemSizingStrategy="MeasureFirstItem"
+                                    RemainingItemsThreshold="10">
+                        
+                        <CollectionView.ItemsLayout>
+                            <LinearItemsLayout Orientation="Vertical" ItemSpacing="5" />
+                        </CollectionView.ItemsLayout>
+                        
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="models:Recipe">
+                                <Frame BorderColor="LightGray" Padding="10" Margin="0,3">
+                                    <Frame.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding BindingContext.EditRecipeCommand, Source={x:Reference ThisPage}}" 
+                                                              CommandParameter="{Binding .}" />
+                                    </Frame.GestureRecognizers>
+                                    <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
+                                        <!-- Kolumna z treścią przepisu -->
+                                        <VerticalStackLayout Grid.Column="0">
+                                            <Label Text="{Binding Name}" FontAttributes="Bold" FontSize="18"/>
+                                            
+                                            <!-- Informacje odżywcze w jednej linii -->
+                                            <StackLayout Orientation="Horizontal" Spacing="15" Margin="0,5,0,0">
+                                                <Label FontSize="12" 
+                                                       TextColor="{AppThemeBinding Light=DarkOrange, Dark=Orange}"
+                                                       FontAttributes="Bold">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="{}{0:F0} kcal">
+                                                            <Binding Path="Calories" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label FontSize="11" 
+                                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="P: {0:F1}g">
+                                                            <Binding Path="Protein" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label FontSize="11" 
+                                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="F: {0:F1}g">
+                                                            <Binding Path="Fat" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label FontSize="11" 
+                                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="C: {0:F1}g">
+                                                            <Binding Path="Carbs" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                            </StackLayout>
+                                        </VerticalStackLayout>
                                         
-                                        <!-- Informacje odżywcze w jednej linii -->
-                                        <StackLayout Orientation="Horizontal" Spacing="15" Margin="0,5,0,0">
-                                            <Label FontSize="12" 
-                                                   TextColor="{AppThemeBinding Light=DarkOrange, Dark=Orange}"
-                                                   FontAttributes="Bold">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="{}{0:F0} kcal">
-                                                        <Binding Path="Calories" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="P: {0:F1}g">
-                                                        <Binding Path="Protein" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="F: {0:F1}g">
-                                                        <Binding Path="Fat" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="C: {0:F1}g">
-                                                        <Binding Path="Carbs" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                        </StackLayout>
-                                    </VerticalStackLayout>
-                                    
-                                    <!-- Przycisk usuwania - zgodny ze stylem ShoppingListDetailPage -->
-                                    <Button Grid.Column="1" 
-                                            Text="✕" 
-                                            Command="{Binding BindingContext.DeleteRecipeCommand, Source={x:Reference ThisPage}}" 
-                                            CommandParameter="{Binding .}" 
-                                            WidthRequest="35" 
-                                            HeightRequest="35"
-                                            BackgroundColor="{AppThemeBinding Light=#FFE6E6, Dark=#4A2C2C}"
-                                            TextColor="{AppThemeBinding Light=#CC0000, Dark=#FF6666}"
-                                            FontSize="16"
-                                            CornerRadius="17"
-                                            BorderColor="{AppThemeBinding Light=#FFCCCC, Dark=#664444}"
-                                            BorderWidth="1"
-                                            VerticalOptions="Center" />
-                                </Grid>
-                            </Frame>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                    
-                    <CollectionView.EmptyView>
-                        <StackLayout HorizontalOptions="Center" VerticalOptions="Center" Padding="20">
-                            <Label Text="{loc:Translate Resource=RecipesPageResources, Key=EmptyTitle}"
-                                   FontSize="18"
-                                   HorizontalOptions="Center"
-                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}" />
-                            <Label Text="{loc:Translate Resource=RecipesPageResources, Key=EmptyHint}"
-                                   FontSize="14"
-                                   HorizontalOptions="Center"
-                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"
-                                   Margin="0,10,0,0" />
-                        </StackLayout>
-                    </CollectionView.EmptyView>
-                    
-                </CollectionView>
+                                        <!-- Przycisk usuwania - zgodny ze stylem ShoppingListDetailPage -->
+                                        <Button Grid.Column="1" 
+                                                Text="✕" 
+                                                Command="{Binding BindingContext.DeleteRecipeCommand, Source={x:Reference ThisPage}}" 
+                                                CommandParameter="{Binding .}" 
+                                                WidthRequest="35" 
+                                                HeightRequest="35"
+                                                BackgroundColor="{AppThemeBinding Light=#FFE6E6, Dark=#4A2C2C}"
+                                                TextColor="{AppThemeBinding Light=#CC0000, Dark=#FF6666}"
+                                                FontSize="16"
+                                                CornerRadius="17"
+                                                BorderColor="{AppThemeBinding Light=#FFCCCC, Dark=#664444}"
+                                                BorderWidth="1"
+                                                VerticalOptions="Center" />
+                                    </Grid>
+                                </Frame>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                        
+                        <CollectionView.EmptyView>
+                            <StackLayout HorizontalOptions="Center" VerticalOptions="Center" Padding="20">
+                                <Label Text="{loc:Translate Resource=RecipesPageResources, Key=EmptyTitle}"
+                                       FontSize="18"
+                                       HorizontalOptions="Center"
+                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}" />
+                                <Label Text="{loc:Translate Resource=RecipesPageResources, Key=EmptyHint}"
+                                       FontSize="14"
+                                       HorizontalOptions="Center"
+                                       TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}"
+                                       Margin="0,10,0,0" />
+                            </StackLayout>
+                        </CollectionView.EmptyView>
+                        
+                    </CollectionView>
+                </VerticalStackLayout>
             </RefreshView>
             
             <!-- Floating Action Button -->

--- a/FoodbookApp.App/Views/RecipesPage.xaml
+++ b/FoodbookApp.App/Views/RecipesPage.xaml
@@ -58,80 +58,67 @@
                          IsVisible="{Binding IsLoading, Converter={StaticResource InvertedBoolConverter}}">
                 
                 <CollectionView ItemsSource="{Binding Recipes}"
-                                ItemSizingStrategy="MeasureFirstItem"
-                                RemainingItemsThreshold="10"
-                                Margin="10,0">
+                                Style="{StaticResource ListCollectionView}"
+                                RemainingItemsThreshold="10">
                     
                     <CollectionView.ItemsLayout>
-                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="5" />
+                        <LinearItemsLayout Orientation="Vertical" ItemSpacing="0" />
                     </CollectionView.ItemsLayout>
                     
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="models:Recipe">
-                            <Frame BorderColor="LightGray" Padding="10" Margin="0,3">
-                                <Frame.GestureRecognizers>
-                                    <TapGestureRecognizer Command="{Binding BindingContext.EditRecipeCommand, Source={x:Reference ThisPage}}" 
-                                                          CommandParameter="{Binding .}" />
-                                </Frame.GestureRecognizers>
-                                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="10">
-                                    <!-- Kolumna z treścią przepisu -->
-                                    <StackLayout Grid.Column="0">
-                                        <Label Text="{Binding Name}" FontAttributes="Bold" FontSize="18"/>
-                                        
-                                        <!-- Informacje odżywcze w jednej linii -->
-                                        <StackLayout Orientation="Horizontal" Spacing="15" Margin="0,5,0,0">
-                                            <Label FontSize="12" 
-                                                   TextColor="{AppThemeBinding Light=DarkOrange, Dark=Orange}"
-                                                   FontAttributes="Bold">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="{}{0:F0} kcal">
-                                                        <Binding Path="Calories" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="P: {0:F1}g">
-                                                        <Binding Path="Protein" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="F: {0:F1}g">
-                                                        <Binding Path="Fat" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
-                                            <Label FontSize="11" 
-                                                   TextColor="{AppThemeBinding Light=Gray, Dark=LightGray}">
-                                                <Label.Text>
-                                                    <MultiBinding StringFormat="C: {0:F1}g">
-                                                        <Binding Path="Carbs" />
-                                                    </MultiBinding>
-                                                </Label.Text>
-                                            </Label>
+                            <ContentView Style="{StaticResource ListItemContainer}">
+                                <Frame Style="{StaticResource ListItemFrame}">
+                                    <Frame.GestureRecognizers>
+                                        <TapGestureRecognizer Command="{Binding BindingContext.EditRecipeCommand, Source={x:Reference ThisPage}}" 
+                                                              CommandParameter="{Binding .}" />
+                                    </Frame.GestureRecognizers>
+                                    <Grid Style="{StaticResource ListItemContentGrid}" ColumnDefinitions="*,Auto">
+                                        <!-- Recipe content column -->
+                                        <StackLayout Grid.Column="0" Spacing="2">
+                                            <Label Text="{Binding Name}" Style="{StaticResource ItemTitleLabel}" />
+                                            
+                                            <!-- Nutrition info in horizontal layout -->
+                                            <StackLayout Style="{StaticResource NutritionContainer}">
+                                                <Label Style="{StaticResource CaloriesLabel}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="{}{0:F0} kcal">
+                                                            <Binding Path="Calories" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label Style="{StaticResource MacroLabel}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="P: {0:F1}g">
+                                                            <Binding Path="Protein" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label Style="{StaticResource MacroLabel}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="F: {0:F1}g">
+                                                            <Binding Path="Fat" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                                <Label Style="{StaticResource MacroLabel}">
+                                                    <Label.Text>
+                                                        <MultiBinding StringFormat="C: {0:F1}g">
+                                                            <Binding Path="Carbs" />
+                                                        </MultiBinding>
+                                                    </Label.Text>
+                                                </Label>
+                                            </StackLayout>
                                         </StackLayout>
-                                    </StackLayout>
-                                    
-                                    <!-- Przycisk usuwania - zgodny ze stylem ShoppingListDetailPage -->
-                                    <Button Grid.Column="1" 
-                                            Text="✕" 
-                                            Command="{Binding BindingContext.DeleteRecipeCommand, Source={x:Reference ThisPage}}" 
-                                            CommandParameter="{Binding .}" 
-                                            WidthRequest="35" 
-                                            HeightRequest="35"
-                                            BackgroundColor="{AppThemeBinding Light=#FFE6E6, Dark=#4A2C2C}"
-                                            TextColor="{AppThemeBinding Light=#CC0000, Dark=#FF6666}"
-                                            FontSize="16"
-                                            CornerRadius="17"
-                                            BorderColor="{AppThemeBinding Light=#FFCCCC, Dark=#664444}"
-                                            BorderWidth="1"
-                                            VerticalOptions="Center" />
-                                </Grid>
-                            </Frame>
+                                        
+                                        <!-- Delete button -->
+                                        <Button Grid.Column="1" 
+                                                Style="{StaticResource DeleteButton}"
+                                                Command="{Binding BindingContext.DeleteRecipeCommand, Source={x:Reference ThisPage}}" 
+                                                CommandParameter="{Binding .}" />
+                                    </Grid>
+                                </Frame>
+                            </ContentView>
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
                     

--- a/FoodbookApp.App/Views/RecipesPage.xaml.cs
+++ b/FoodbookApp.App/Views/RecipesPage.xaml.cs
@@ -32,10 +32,5 @@ namespace Foodbook.Views
                 await _viewModel.ReloadAsync();
             }
         }
-
-        private async void OnAddRecipeClicked(object sender, EventArgs e)
-        {
-            await Shell.Current.GoToAsync(nameof(AddRecipePage));
-        }
     }
 }

--- a/FoodbookApp.App/Views/SettingsPage.xaml
+++ b/FoodbookApp.App/Views/SettingsPage.xaml
@@ -38,6 +38,28 @@
             <Setter Property="Margin" Value="0,12,0,0" />
         </Style>
         
+        <!-- Migration Button Style -->
+        <Style x:Key="MigrationButtonStyle" TargetType="Button">
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Secondary}, Dark={StaticResource SecondaryDark}}" />
+            <Setter Property="TextColor" Value="White" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="FontAttributes" Value="Bold" />
+            <Setter Property="HeightRequest" Value="40" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Margin" Value="0,8,0,0" />
+        </Style>
+        
+        <!-- Danger Button Style -->
+        <Style x:Key="DangerButtonStyle" TargetType="Button">
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#DC3545, Dark=#C62D3A}" />
+            <Setter Property="TextColor" Value="White" />
+            <Setter Property="FontSize" Value="14" />
+            <Setter Property="FontAttributes" Value="Bold" />
+            <Setter Property="HeightRequest" Value="40" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Margin" Value="0,8,0,0" />
+        </Style>
+        
         <!-- Disabled Button Style -->
         <Style x:Key="DisabledButtonStyle" TargetType="Button">
             <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}" />
@@ -70,6 +92,15 @@
             <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray400}, Dark={StaticResource Gray500}}" />
             <Setter Property="Margin" Value="0,4" />
         </Style>
+
+        <!-- Status Label Style -->
+        <Style x:Key="StatusLabelStyle" TargetType="Label">
+            <Setter Property="FontSize" Value="12" />
+            <Setter Property="HorizontalTextAlignment" Value="Center" />
+            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+            <Setter Property="FontAttributes" Value="Italic" />
+            <Setter Property="Margin" Value="0,8,0,0" />
+        </Style>
     </ContentPage.Resources>
 
     <ScrollView BackgroundColor="Transparent">
@@ -99,7 +130,7 @@
 
             <!-- Settings Grid -->
             <Grid ColumnDefinitions="*,*" 
-                  RowDefinitions="Auto,Auto,Auto"
+                  RowDefinitions="Auto,Auto,Auto,Auto"
                   ColumnSpacing="0"
                   RowSpacing="8">
 
@@ -125,8 +156,43 @@
                     </StackLayout>
                 </Frame>
 
+                <!-- Database Migration Card -->
+                <Frame Grid.Row="1" Grid.Column="0" Style="{StaticResource DashboardCardStyle}">
+                    <StackLayout>
+                        <Label Text="Migracja bazy danych" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="Aktualizuj strukturę bazy danych do najnowszej wersji"
+                               Style="{StaticResource DescriptionStyle}" />
+                        <Button Text="Wykonaj migrację"
+                                Style="{StaticResource MigrationButtonStyle}"
+                                Command="{Binding MigrateDatabaseCommand}"
+                                IsEnabled="{Binding CanExecuteMigration}" />
+                        <Label Text="{Binding MigrationStatus}"
+                               Style="{StaticResource StatusLabelStyle}"
+                               IsVisible="{Binding MigrationStatus, Converter={StaticResource IsNotNullOrEmptyConverter}}" />
+                    </StackLayout>
+                </Frame>
+
+                <!-- Database Reset Card -->
+                <Frame Grid.Row="1" Grid.Column="1" Style="{StaticResource DashboardCardStyle}">
+                    <StackLayout>
+                        <Label Text="Reset bazy danych" Style="{StaticResource CardTitleStyle}" />
+                        <Label Text="⚠️ Usuń wszystkie dane i przywróć ustawienia domyślne"
+                               Style="{StaticResource DescriptionStyle}" />
+                        <Button Text="Resetuj bazę"
+                                Style="{StaticResource DangerButtonStyle}"
+                                Command="{Binding ResetDatabaseCommand}"
+                                IsEnabled="{Binding CanExecuteMigration}" />
+                        <Label Text="Operacja nieodwracalna!"
+                               FontSize="10"
+                               HorizontalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light=#DC3545, Dark=#C62D3A}"
+                               FontAttributes="Bold"
+                               Margin="0,4,0,0" />
+                    </StackLayout>
+                </Frame>
+
                 <!-- Version Info Card -->
-                <Frame Grid.Row="1" Grid.ColumnSpan="2" Style="{StaticResource DashboardCardStyle}">
+                <Frame Grid.Row="2" Grid.ColumnSpan="2" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
                         <Label Text="{loc:Translate Resource=SettingsPageResources, Key=VersionInfoTitle}" Style="{StaticResource CardTitleStyle}" />
                         
@@ -154,7 +220,7 @@
                 </Frame>
 
                 <!-- Data Export Card -->
-                <Frame Grid.Row="2" Grid.ColumnSpan="2" Style="{StaticResource DashboardCardStyle}">
+                <Frame Grid.Row="3" Grid.ColumnSpan="2" Style="{StaticResource DashboardCardStyle}">
                     <StackLayout>
                         <Label Text="{loc:Translate Resource=SettingsPageResources, Key=DataExportTitle}" Style="{StaticResource CardTitleStyle}" />
                         <Label Text="{loc:Translate Resource=SettingsPageResources, Key=DataExportDescription}"


### PR DESCRIPTION
This pull request introduces significant improvements to the application's database reliability, data seeding performance, and UI theming. The most notable changes include the addition of robust database migration and schema validation logic, batching for ingredient seeding, theme-aware color logic in converters, and new value converters for UI binding. Below are the most important changes grouped by theme:

**Database Migration, Validation, and Seeding Improvements**
- Added comprehensive methods for database migration, schema validation, and full database reset in `MauiProgram.cs`, including logic to validate table schemas, add missing columns, manage schema versions, and apply migrations safely. This ensures the database structure is always up-to-date and resilient to schema drift. [[1]](diffhunk://#diff-168268e86b97d5ecc9c698440a3715de24533b90391a87544ae90efbd7587052R101-R460) [[2]](diffhunk://#diff-168268e86b97d5ecc9c698440a3715de24533b90391a87544ae90efbd7587052R474-R476)
- Optimized ingredient seeding in `SeedData.cs` by batching inserts for better performance and UI responsiveness, and improved logging for batch progress and errors.
- Set a shorter HTTP timeout (10 seconds) for OpenFoodFacts API calls to make ingredient data updates more responsive.
- Increased the update threshold for ingredient nutrition fields to 0.5 (from 0.1) to avoid unnecessary updates for minor differences, and improved logging for update actions and errors.

**UI and Theming Enhancements**
- Updated `BoolToColorConverter` to provide theme-aware color responses for various UI elements, including text, tab backgrounds, and borders, ensuring consistent appearance in both light and dark modes.
- Added new colors, such as `SecondaryDark`, to the color resources for improved dark mode support.

**Converters and Styles**
- Introduced a new `IsNotNullOrEmptyConverter` for use in XAML bindings, and registered multiple converters in `Styles.xaml` for streamlined UI development. [[1]](diffhunk://#diff-863444eae4a09a533a8e77619b6151607caad0c8d462a5d7ba06fce2861c0efaR160-R172) [[2]](diffhunk://#diff-1fe9db3356420c117f2a1b0e37d56bc450539b5e0d397eeab847b00547dff297L5-R17)