### PR TITLE
Profile page: dynamic counters and subscription status loading

### DIFF
--- a/FoodbookApp.App/Views/ProfilePage.xaml
+++ b/FoodbookApp.App/Views/ProfilePage.xaml
@@ -47,19 +47,19 @@
                     <Grid ColumnDefinitions="*,*,*" ColumnSpacing="8">
                         <Border Grid.Column="0" BackgroundColor="{DynamicResource AppHeroTileOverlayColor}" StrokeThickness="0" Padding="8,7" StrokeShape="RoundRectangle 12">
                             <VerticalStackLayout Spacing="0">
-                                <Label Text="0" FontSize="16" FontAttributes="Bold" TextColor="White" HorizontalTextAlignment="Center" />
+                                <Label x:Name="RecipesCountLabel" Text="0" FontSize="16" FontAttributes="Bold" TextColor="White" HorizontalTextAlignment="Center" />
                                 <Label Text="Przepisy" FontSize="10" TextColor="{DynamicResource AppHeroHintTextColor}" HorizontalTextAlignment="Center" />
                             </VerticalStackLayout>
                         </Border>
                         <Border Grid.Column="1" BackgroundColor="{DynamicResource AppHeroTileOverlayColor}" StrokeThickness="0" Padding="8,7" StrokeShape="RoundRectangle 12">
                             <VerticalStackLayout Spacing="0">
-                                <Label Text="0" FontSize="16" FontAttributes="Bold" TextColor="White" HorizontalTextAlignment="Center" />
+                                <Label x:Name="PlansCountLabel" Text="0" FontSize="16" FontAttributes="Bold" TextColor="White" HorizontalTextAlignment="Center" />
                                 <Label Text="Plany" FontSize="10" TextColor="{DynamicResource AppHeroHintTextColor}" HorizontalTextAlignment="Center" />
                             </VerticalStackLayout>
                         </Border>
                         <Border Grid.Column="2" BackgroundColor="{DynamicResource AppHeroTileOverlayColor}" StrokeThickness="0" Padding="8,7" StrokeShape="RoundRectangle 12">
                             <VerticalStackLayout Spacing="0">
-                                <Label Text="0" FontSize="16" FontAttributes="Bold" TextColor="White" HorizontalTextAlignment="Center" />
+                                <Label x:Name="ListsCountLabel" Text="0" FontSize="16" FontAttributes="Bold" TextColor="White" HorizontalTextAlignment="Center" />
                                 <Label Text="Listy" FontSize="10" TextColor="{DynamicResource AppHeroHintTextColor}" HorizontalTextAlignment="Center" />
                             </VerticalStackLayout>
                         </Border>
@@ -79,11 +79,11 @@
                             <Grid ColumnDefinitions="Auto,*,Auto,Auto" ColumnSpacing="10">
                                 <Label Text="✨" FontSize="22" VerticalOptions="Center" />
                                 <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
-                                    <Label Text="Premium" FontSize="16" FontAttributes="Bold" TextColor="White" />
-                                    <Label Text="Aktywny · odnowienie 15.04.2026" FontSize="12" TextColor="{DynamicResource AppHeroSubtitleTextColor}" />
+                                    <Label x:Name="CurrentPlanNameLabel" Text="" FontSize="16" FontAttributes="Bold" TextColor="White" />
+                                    <Label x:Name="CurrentPlanRenewalLabel" Text="" FontSize="12" TextColor="{DynamicResource AppHeroSubtitleTextColor}" />
                                 </VerticalStackLayout>
                                 <Border Grid.Column="2" BackgroundColor="{DynamicResource ProfilePlanActiveBadgeBackgroundColor}" StrokeThickness="0" Padding="8,4" StrokeShape="RoundRectangle 10" VerticalOptions="Center">
-                                    <Label Text="Aktywny" FontSize="10" FontAttributes="Bold" TextColor="{DynamicResource ProfilePlanActiveBadgeTextColor}" />
+                                    <Label x:Name="CurrentPlanStatusLabel" Text="" FontSize="10" FontAttributes="Bold" TextColor="{DynamicResource ProfilePlanActiveBadgeTextColor}" />
                                 </Border>
                                 <Label Grid.Column="3" Text="›" FontSize="18" TextColor="{DynamicResource AppHeroHintTextColor}" VerticalOptions="Center" />
                             </Grid>
@@ -183,9 +183,9 @@
                         <VerticalStackLayout Spacing="8">
                             <Grid ColumnDefinitions="Auto,*,Auto" ColumnSpacing="10">
                                 <Label Text="✨" FontSize="24" VerticalOptions="Center" />
-                                <Label Grid.Column="1" Text="Premium" FontSize="20" FontAttributes="Bold" TextColor="White" VerticalOptions="Center" />
+                                <Label x:Name="CurrentPlanNameDetailsLabel" Grid.Column="1" Text="" FontSize="20" FontAttributes="Bold" TextColor="White" VerticalOptions="Center" />
                                 <Border Grid.Column="2" BackgroundColor="{DynamicResource ProfilePlanActiveBadgeBackgroundColor}" StrokeThickness="0" Padding="9,4" StrokeShape="RoundRectangle 12" VerticalOptions="Center">
-                                    <Label Text="Aktywny" FontSize="10" FontAttributes="Bold" TextColor="{DynamicResource ProfilePlanActiveBadgeTextColor}" />
+                                    <Label x:Name="CurrentPlanStatusDetailsLabel" Text="" FontSize="10" FontAttributes="Bold" TextColor="{DynamicResource ProfilePlanActiveBadgeTextColor}" />
                                 </Border>
                             </Grid>
 
@@ -199,7 +199,7 @@
                                 <Label Text="✓ Premium paczki przepisów" FontSize="12" TextColor="{DynamicResource AppHeroSubtitleTextColor}" />
                             </VerticalStackLayout>
 
-                            <Label Text="Następne odnowienie: 15 kwietnia 2026" FontSize="11" TextColor="{DynamicResource AppHeroHintTextColor}" />
+                            <Label x:Name="CurrentPlanRenewalDetailsLabel" Text="" FontSize="11" TextColor="{DynamicResource AppHeroHintTextColor}" />
                         </VerticalStackLayout>
                     </Border>
 

--- a/FoodbookApp.App/Views/ProfilePage.xaml.cs
+++ b/FoodbookApp.App/Views/ProfilePage.xaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using CommunityToolkit.Maui.Extensions;
 using Foodbook.Data;
 using Foodbook.Models;
+using Foodbook.Services;
 using Foodbook.Views.Components;
 using FoodbookApp.Interfaces;
 using FoodbookApp.Localization;
@@ -19,9 +20,11 @@ public partial class ProfilePage : ContentPage
     private ISupabaseAuthService? _supabaseAuth;
     private ISupabaseSyncService? _syncService;
     private IAccountService? _accountService;
+    private IFeatureAccessService? _featureAccessService;
     private CancellationTokenSource? _syncRefreshCts;
     private bool _isLoggedIn;
     private bool _suppressToggle;
+    private bool _eventsSubscribed;
     private string _currentUserEmail = string.Empty;
 
     private const string SyncChoiceKeyPrefix = "cloudsync.enabled:";
@@ -40,14 +43,18 @@ public partial class ProfilePage : ContentPage
     protected override async void OnAppearing()
     {
         base.OnAppearing();
+        SubscribeToAppEvents();
         StartSyncStatusRefresh();
         await CheckAndRestoreSessionAsync();
+        await LoadProfileStatsAsync();
+        await LoadCurrentSubscriptionUiAsync();
         if (_isLoggedIn)
             await LoadSyncStatusAsync();
     }
 
     protected override void OnDisappearing()
     {
+        UnsubscribeFromAppEvents();
         StopSyncStatusRefresh();
         base.OnDisappearing();
     }
@@ -249,6 +256,115 @@ public partial class ProfilePage : ContentPage
         _suppressToggle = true;
         try { CloudSyncSwitch.IsToggled = value; }
         finally { _suppressToggle = false; }
+    }
+
+    #endregion
+
+    #region Profile Stats & Subscription
+
+    private void SubscribeToAppEvents()
+    {
+        if (_eventsSubscribed)
+            return;
+
+        AppEvents.PlanChangedAsync += OnAppDataChangedAsync;
+        AppEvents.RecipesChangedAsync += OnAppDataChangedAsync;
+        _eventsSubscribed = true;
+    }
+
+    private void UnsubscribeFromAppEvents()
+    {
+        if (!_eventsSubscribed)
+            return;
+
+        AppEvents.PlanChangedAsync -= OnAppDataChangedAsync;
+        AppEvents.RecipesChangedAsync -= OnAppDataChangedAsync;
+        _eventsSubscribed = false;
+    }
+
+    private async Task OnAppDataChangedAsync()
+    {
+        await RefreshProfileDataAsync();
+    }
+
+    private async Task RefreshProfileDataAsync()
+    {
+        try
+        {
+            await LoadProfileStatsAsync();
+            await LoadCurrentSubscriptionUiAsync();
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[ProfilePage] RefreshProfileDataAsync error: {ex.Message}");
+        }
+    }
+
+    private async Task LoadProfileStatsAsync()
+    {
+        try
+        {
+            var serviceProvider = FoodbookApp.MauiProgram.ServiceProvider;
+            if (serviceProvider == null)
+                return;
+
+            using var scope = serviceProvider.CreateScope();
+            var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+            var utcNow = DateTime.UtcNow;
+
+            var recipesCount = await db.Recipes.CountAsync();
+            var plansCount = await db.Plans.CountAsync(p =>
+                p.Type == PlanType.Planner &&
+                !p.IsArchived &&
+                p.StartDate <= utcNow &&
+                p.EndDate >= utcNow);
+            var listsCount = await db.Plans.CountAsync(p =>
+                p.Type == PlanType.ShoppingList &&
+                !p.IsArchived);
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                RecipesCountLabel.Text = recipesCount.ToString();
+                PlansCountLabel.Text = plansCount.ToString();
+                ListsCountLabel.Text = listsCount.ToString();
+            });
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[ProfilePage] LoadProfileStatsAsync error: {ex.Message}");
+        }
+    }
+
+    private async Task LoadCurrentSubscriptionUiAsync()
+    {
+        try
+        {
+            var featureAccess = GetFeatureAccessService();
+            if (featureAccess == null)
+                return;
+
+            var isPremium = await featureAccess.CanUsePremiumFeatureAsync(PremiumFeature.AutoPlanner);
+            var currentPlanName = isPremium ? "Premium" : "Free";
+            var currentPlanStatus = isPremium ? "Aktywny" : "Nieaktywny";
+            var renewalText = isPremium
+                ? "Dostęp premium aktywny"
+                : "Brak aktywnej subskrypcji";
+
+            await MainThread.InvokeOnMainThreadAsync(() =>
+            {
+                CurrentPlanNameLabel.Text = currentPlanName;
+                CurrentPlanStatusLabel.Text = currentPlanStatus;
+                CurrentPlanRenewalLabel.Text = renewalText;
+
+                CurrentPlanNameDetailsLabel.Text = currentPlanName;
+                CurrentPlanStatusDetailsLabel.Text = currentPlanStatus;
+                CurrentPlanRenewalDetailsLabel.Text = renewalText;
+            });
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"[ProfilePage] LoadCurrentSubscriptionUiAsync error: {ex.Message}");
+        }
     }
 
     #endregion
@@ -490,6 +606,9 @@ public partial class ProfilePage : ContentPage
 
     private IAccountService? GetAccountService()
         => _accountService ??= FoodbookApp.MauiProgram.ServiceProvider?.GetService<IAccountService>();
+
+    private IFeatureAccessService? GetFeatureAccessService()
+        => _featureAccessService ??= FoodbookApp.MauiProgram.ServiceProvider?.GetService<IFeatureAccessService>();
 
     #endregion
 


### PR DESCRIPTION
### Motivation

- Umożliwić aktualizowanie liczników (przepisy/plany/listy) i statusu subskrypcji w runtime zamiast trzymać je jako hardcoded tekst w XAML.  
- Odświeżać widok profilu automatycznie po zmianach danych (plany/przepisy) aby UI zawsze pokazywało aktualne informacje.

### Description

- Dodano `x:Name` do etykiet w `ProfilePage.xaml`: `RecipesCountLabel`, `PlansCountLabel`, `ListsCountLabel` i etykiet statusu planu `CurrentPlanNameLabel`, `CurrentPlanStatusLabel`, `CurrentPlanRenewalLabel` oraz ich odpowiedniki w widoku szczegółów (`CurrentPlanNameDetailsLabel`, `CurrentPlanStatusDetailsLabel`, `CurrentPlanRenewalDetailsLabel`) i usunięto hardcoded daty/statusy z XAML.  
- Zaimplementowano `LoadProfileStatsAsync()` w `ProfilePage.xaml.cs`, które używa `AppDbContext` i wykonuje `db.Recipes.CountAsync()`, liczy aktywne, niearchiwalne plany typu `PlanType.Planner` (z uwzględnieniem zakresu dat) oraz niearchiwalne listy (`PlanType.ShoppingList`), a wyniki aktualizuje na UI za pomocą `MainThread`.  
- Dodano `LoadCurrentSubscriptionUiAsync()` korzystające z `IFeatureAccessService` (wykorzystanie metody `CanUsePremiumFeatureAsync(PremiumFeature.AutoPlanner)`) do ustawiania nazwy planu, statusu i tekstu odnowienia w odpowiednich etykietach.  
- Podpięto odświeżanie danych: wywołania w `OnAppearing()`, oraz subskrypcje `AppEvents.PlanChangedAsync` i `AppEvents.RecipesChangedAsync` z bezpiecznym unsubscribe w `OnDisappearing()`, dodano locator `GetFeatureAccessService()` i pole `_featureAccessService`.

### Testing

- Próbowano zbudować projekt poleceniem `dotnet build FoodbookApp.App/FoodbookApp.App.csproj -v minimal`, ale budowanie nie mogło zostać wykonane w tym środowisku ponieważ `dotnet` nie jest zainstalowane (`/bin/bash: dotnet: command not found`).  
- Nie uruchomiono żadnych zautomatyzowanych testów lokalnie w tym środowisku; zmiany zostały zakomitowane w repozytorium po wprowadzeniu poprawek.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c27af028648329b6e68253cbb9f91f)