### PR TITLE
Gate AI fallback behind premium access; expose import status and add tests

### DIFF
--- a/FoodbookApp.App/Models/Recipe.cs
+++ b/FoodbookApp.App/Models/Recipe.cs
@@ -29,6 +29,12 @@ namespace Foodbook.Models
         [NotMapped]
         public bool IsBeingDraggedOver { get; set; }
 
+        [NotMapped]
+        public bool HasUnmatchedIngredients { get; set; }
+
+        [NotMapped]
+        public bool WasAiFallbackUsed { get; set; }
+
         public List<Ingredient> Ingredients { get; set; } = new List<Ingredient>();
 
         // Labels (many-to-many via join table RecipeRecipeLabel)

--- a/FoodbookApp.App/Services/RecipeImporter.cs
+++ b/FoodbookApp.App/Services/RecipeImporter.cs
@@ -53,11 +53,12 @@ public class RecipeImporter
 
     // ─── Publiczne API ────────────────────────────────────────────────────────
 
-    public async Task<Recipe> ImportFromUrlAsync(string url)
+    public async Task<Recipe> ImportFromUrlAsync(string url, bool allowAiFallback)
     {
         Debug.WriteLine($"{Tag} ══════════════════════════════════════════");
         Debug.WriteLine($"{Tag} START import: {url}");
-        Debug.WriteLine($"{Tag} AI fallback dostępny: {(_aiService is not null ? "TAK" : "NIE")}");
+        Debug.WriteLine($"{Tag} AI fallback dozwolony: {(allowAiFallback ? "TAK" : "NIE")}");
+        Debug.WriteLine($"{Tag} AI fallback dostępny technicznie: {(_aiService is not null ? "TAK" : "NIE")}");
 
         var html = await _httpClient.GetStringAsync(url);
         Debug.WriteLine($"{Tag} HTML pobrany, rozmiar: {html.Length:N0} znaków");
@@ -149,6 +150,7 @@ public class RecipeImporter
         }
 
         Debug.WriteLine($"{Tag} Składniki po parsowaniu lokalnym: {parsedIngredients.Count} dopasowanych, {unmatchedLines.Count} niedopasowanych");
+        recipe.HasUnmatchedIngredients = unmatchedLines.Count > 0;
 
         // 2. WARTOŚCI ODŻYWCZE
         ExtractNutrition(doc, recipe);
@@ -156,8 +158,10 @@ public class RecipeImporter
 
         // 3. AI FALLBACK
         var aiSuccess = false;
-        if (unmatchedLines.Count > 0 && _aiService is not null)
+        var localParserWasInsufficient = unmatchedLines.Count > 0;
+        if (allowAiFallback && localParserWasInsufficient && _aiService is not null)
         {
+            recipe.WasAiFallbackUsed = true;
             Debug.WriteLine($"{Tag} ── AI FALLBACK ──────────────────────────────");
             Debug.WriteLine($"{Tag} Wywołuję AI dla {unmatchedLines.Count} niedopasowanych składników:");
             for (int i = 0; i < unmatchedLines.Count; i++)
@@ -231,7 +235,11 @@ public class RecipeImporter
                 Debug.WriteLine($"{Tag} AI WYJĄTEK: {ex.GetType().Name}: {ex.Message}");
             }
         }
-        else if (unmatchedLines.Count == 0)
+        else if (!allowAiFallback)
+        {
+            Debug.WriteLine($"{Tag} AI fallback: pominięty — brak uprawnień (allowAiFallback=false)");
+        }
+        else if (!localParserWasInsufficient)
         {
             Debug.WriteLine($"{Tag} AI fallback: pominięty — wszystkie składniki dopasowane lokalnie");
         }

--- a/FoodbookApp.App/ViewModels/AddRecipeViewModel.cs
+++ b/FoodbookApp.App/ViewModels/AddRecipeViewModel.cs
@@ -200,13 +200,15 @@ namespace Foodbook.ViewModels
         private readonly IRecipeService _recipeService;
         private readonly IIngredientService _ingredientService;
         private readonly RecipeImporter _importer;
+        private readonly IFeatureAccessService _featureAccessService;
 
-        public AddRecipeViewModel(IRecipeService recipeService, IIngredientService ingredientService, RecipeImporter importer, IFolderService folderService, IDatabaseService? databaseService = null, IRecipeLabelService? labelService = null)
+        public AddRecipeViewModel(IRecipeService recipeService, IIngredientService ingredientService, RecipeImporter importer, IFolderService folderService, IDatabaseService? databaseService = null, IRecipeLabelService? labelService = null, IFeatureAccessService? featureAccessService = null)
         {
             _recipeService = recipeService ?? throw new ArgumentNullException(nameof(recipeService));
             _ingredientService = ingredientService ?? throw new ArgumentNullException(nameof(ingredientService));
             _importer = importer ?? throw new ArgumentNullException(nameof(importer));
             _folderService = folderService ?? throw new ArgumentNullException(nameof(folderService));
+            _featureAccessService = featureAccessService ?? ResolveFeatureAccessService() ?? new NullFeatureAccessService();
 
             _databaseService = databaseService ?? ResolveDatabaseService() ?? new NullDatabaseService();
             _labelService = labelService ?? ResolveLabelService() ?? new NullLabelService();
@@ -291,6 +293,18 @@ namespace Foodbook.ViewModels
             }
         }
 
+        private IFeatureAccessService? ResolveFeatureAccessService()
+        {
+            try
+            {
+                return Application.Current?.Handler?.MauiContext?.Services?.GetService<IFeatureAccessService>();
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
         private sealed class NullDatabaseService : IDatabaseService
         {
             public Task InitializeAsync() => Task.CompletedTask;
@@ -308,6 +322,17 @@ namespace Foodbook.ViewModels
             public Task<List<RecipeLabel>> GetAllAsync(CancellationToken ct = default) => Task.FromResult(new List<RecipeLabel>());
             public Task<RecipeLabel?> GetByIdAsync(Guid id, CancellationToken ct = default) => Task.FromResult<RecipeLabel?>(null);
             public Task<RecipeLabel> UpdateAsync(RecipeLabel label, CancellationToken ct = default) => Task.FromResult(label);
+        }
+
+        private sealed class NullFeatureAccessService : IFeatureAccessService
+        {
+            public Task<bool> CanCreatePlanAsync() => Task.FromResult(false);
+            public Task<PlanLimitDecision> CanCreatePlanAsync(PlanType type, DateTime nowUtc) => Task.FromResult(PlanLimitDecision.Denied(string.Empty));
+            public Task RegisterPlanCreationAsync(PlanType type, DateTime nowUtc) => Task.CompletedTask;
+            public Task<bool> CanUsePremiumFeatureAsync(PremiumFeature feature) => Task.FromResult(false);
+            public Task<AdUnlockResult> RequestAdUnlockAsync(PremiumFeature feature) => Task.FromResult(new AdUnlockResult { Success = false, Feature = feature });
+            public bool IsAdUnlockActive(PremiumFeature feature) => false;
+            public Task RefreshAccessAsync() => Task.CompletedTask;
         }
 
         public async Task LoadAvailableFoldersAsync()
@@ -772,7 +797,8 @@ namespace Foodbook.ViewModels
             try
             {
                 ImportStatus = "Importowanie...";
-                var recipe = await _importer.ImportFromUrlAsync(ImportUrl);
+                var allowAiFallback = await _featureAccessService.CanUsePremiumFeatureAsync(PremiumFeature.AiRecipeCreation);
+                var recipe = await _importer.ImportFromUrlAsync(ImportUrl, allowAiFallback);
                 Name = recipe.Name;
                 Description = recipe.Description ?? string.Empty;
                 
@@ -804,7 +830,18 @@ namespace Foodbook.ViewModels
                     Carbs = recipe.Carbs.ToString("F1");
                 }
                 
-                ImportStatus = "Zaimportowano!";
+                if (!allowAiFallback && recipe.HasUnmatchedIngredients)
+                {
+                    ImportStatus = "Import AI dostępny w Premium";
+                }
+                else if (allowAiFallback && recipe.WasAiFallbackUsed)
+                {
+                    ImportStatus = "Uruchomiono AI fallback";
+                }
+                else
+                {
+                    ImportStatus = "Zaimportowano!";
+                }
                 IsManualMode = true; // Przełącz na tryb ręczny po imporcie
             }
             catch (Exception ex)

--- a/FoodbookApp.Tests/AddRecipePageTests.cs
+++ b/FoodbookApp.Tests/AddRecipePageTests.cs
@@ -3,9 +3,14 @@ using Foodbook.Models;
 using Foodbook.Services;
 using Foodbook.ViewModels;
 using FoodbookApp.Interfaces;
+using FoodbookApp.Services;
 using Microsoft.Maui.Controls;
 using Moq;
 using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
 
 namespace FoodbookApp.Tests
 {
@@ -119,6 +124,122 @@ namespace FoodbookApp.Tests
 
             // Assert
             _viewModel.Ingredients.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task ImportRecipeAsync_FreeWithUnmatchedIngredients_ShouldSkipAiAndShowPremiumMessage()
+        {
+            // Arrange
+            var aiServiceMock = new Mock<IAIService>(MockBehavior.Strict);
+            var ingredientServiceMock = new Mock<IIngredientService>();
+            ingredientServiceMock.Setup(s => s.GetIngredientsAsync()).ReturnsAsync(new List<Ingredient>());
+
+            var featureAccessMock = new Mock<IFeatureAccessService>();
+            featureAccessMock.Setup(s => s.CanUsePremiumFeatureAsync(PremiumFeature.AiRecipeCreation)).ReturnsAsync(false);
+
+            var importer = new RecipeImporter(
+                CreateHttpClientWithHtml("<html><body><h2>Składniki</h2><ul><li>1 marchewka</li></ul></body></html>"),
+                ingredientServiceMock.Object,
+                aiServiceMock.Object);
+            var viewModel = CreateViewModel(importer, ingredientServiceMock.Object, featureAccessMock.Object);
+            viewModel.ImportUrl = "https://example.com/free";
+
+            // Act
+            await InvokeImportRecipeAsync(viewModel);
+
+            // Assert
+            viewModel.ImportStatus.Should().Be("Import AI dostępny w Premium");
+            aiServiceMock.Verify(s => s.GetAIResponseAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ImportRecipeAsync_PremiumWithFullLocalMatch_ShouldNotCallAiAndShowImportedStatus()
+        {
+            // Arrange
+            var aiServiceMock = new Mock<IAIService>(MockBehavior.Strict);
+            var ingredientServiceMock = new Mock<IIngredientService>();
+            ingredientServiceMock
+                .Setup(s => s.GetIngredientsAsync())
+                .ReturnsAsync(new List<Ingredient> { new() { Name = "mleko", Calories = 64 } });
+
+            var featureAccessMock = new Mock<IFeatureAccessService>();
+            featureAccessMock.Setup(s => s.CanUsePremiumFeatureAsync(PremiumFeature.AiRecipeCreation)).ReturnsAsync(true);
+
+            var importer = new RecipeImporter(
+                CreateHttpClientWithHtml("<html><body><h2>Składniki</h2><ul><li>200 ml mleko</li></ul></body></html>"),
+                ingredientServiceMock.Object,
+                aiServiceMock.Object);
+            var viewModel = CreateViewModel(importer, ingredientServiceMock.Object, featureAccessMock.Object);
+            viewModel.ImportUrl = "https://example.com/premium-local";
+
+            // Act
+            await InvokeImportRecipeAsync(viewModel);
+
+            // Assert
+            viewModel.ImportStatus.Should().Be("Zaimportowano!");
+            aiServiceMock.Verify(s => s.GetAIResponseAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task ImportRecipeAsync_PremiumWithUnmatchedIngredients_ShouldCallAiAndShowFallbackStatus()
+        {
+            // Arrange
+            var aiServiceMock = new Mock<IAIService>();
+            aiServiceMock
+                .Setup(s => s.GetAIResponseAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync("""{"title":"Test","calories":0,"protein":0,"fat":0,"carbs":0,"ingredients":[{"raw_name":"1 marchewka","quantity":1,"unit":"piece","matched_db_name":null}]}""");
+
+            var ingredientServiceMock = new Mock<IIngredientService>();
+            ingredientServiceMock.Setup(s => s.GetIngredientsAsync()).ReturnsAsync(new List<Ingredient>());
+
+            var featureAccessMock = new Mock<IFeatureAccessService>();
+            featureAccessMock.Setup(s => s.CanUsePremiumFeatureAsync(PremiumFeature.AiRecipeCreation)).ReturnsAsync(true);
+
+            var importer = new RecipeImporter(
+                CreateHttpClientWithHtml("<html><body><h2>Składniki</h2><ul><li>1 marchewka</li></ul></body></html>"),
+                ingredientServiceMock.Object,
+                aiServiceMock.Object);
+            var viewModel = CreateViewModel(importer, ingredientServiceMock.Object, featureAccessMock.Object);
+            viewModel.ImportUrl = "https://example.com/premium-ai";
+
+            // Act
+            await InvokeImportRecipeAsync(viewModel);
+
+            // Assert
+            viewModel.ImportStatus.Should().Be("Uruchomiono AI fallback");
+            aiServiceMock.Verify(s => s.GetAIResponseAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private AddRecipeViewModel CreateViewModel(RecipeImporter importer, IIngredientService ingredientService, IFeatureAccessService featureAccessService)
+            => new(
+                _mockRecipeService.Object,
+                ingredientService,
+                importer,
+                _mockFolderService.Object,
+                featureAccessService: featureAccessService);
+
+        private static async Task InvokeImportRecipeAsync(AddRecipeViewModel viewModel)
+        {
+            var method = typeof(AddRecipeViewModel).GetMethod("ImportRecipeAsync", BindingFlags.Instance | BindingFlags.NonPublic);
+            method.Should().NotBeNull();
+            var task = method!.Invoke(viewModel, null) as Task;
+            task.Should().NotBeNull();
+            await task!;
+        }
+
+        private static HttpClient CreateHttpClientWithHtml(string html)
+            => new(new StubHttpMessageHandler(html))
+            {
+                BaseAddress = new Uri("https://example.com")
+            };
+
+        private sealed class StubHttpMessageHandler(string html) : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+                => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(html, Encoding.UTF8, "text/html")
+                });
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Ograniczyć wywoływanie AI podczas importu przepisów tylko do użytkowników z dostępem Premium i tylko gdy lokalny parser nie dopasował wszystkich składników. 
- Przekazać informację do UI o tym, czy lokalny parser miał niedopasowania i czy AI fallback został faktycznie użyty, aby poprawnie pokazać status importu. 
- Dodać testy jednostkowe pokrywające scenariusze Free/Premium z oraz bez wywołania AI.

### Description
- Zmieniono sygnaturę `RecipeImporter.ImportFromUrlAsync` na `ImportFromUrlAsync(string url, bool allowAiFallback)` i dodano warunek uruchamiania AI fallback tylko gdy `allowAiFallback == true`, lokalny parser zostawił niedopasowane linie oraz serwis AI jest dostępny. 
- Dodano nierelacyjne pola w modelu `Recipe`: `HasUnmatchedIngredients` oraz `WasAiFallbackUsed` by przekazać wynik decyzji fallbacku do wywołującego. 
- Zaktualizowano `AddRecipeViewModel` by pobierać uprawnienie Premium przez `IFeatureAccessService`, przekazywać `allowAiFallback` do importera i ustawiać komunikaty statusu importu (`Import AI dostępny w Premium`, `Uruchomiono AI fallback`, lub `Zaimportowano!`). 
- Dodano trzy testy jednostkowe w `AddRecipePageTests` sprawdzające: Free użytkownik z niedopasowaniami (bez wywołania AI), Premium z pełnym dopasowaniem lokalnym (bez wywołania AI), oraz Premium z niedopasowaniami (AI jest wywoływane).

### Testing
- Dodano testy jednostkowe (`AddRecipePageTests`) dla trzech scenariuszy opisanych wyżej, wszystkie testy są zaimplementowane w projekcie testowym. 
- Próbowano uruchomić testy lokalnie z poleceniem `dotnet test FoodbookApp.Tests/FoodbookApp.Tests.csproj --filter AddRecipePageTests`, lecz środowisko wykonawcze nie ma zainstalowanego SDK i testy nie zostały uruchomione (`/bin/bash: dotnet: command not found`). 
- W repozytorium pozostaje możliwość uruchomienia testów w środowisku CI/deweloperskim z zainstalowanym .NET SDK, gdzie nowe testy powinny weryfikować zachowania opisane powyżej.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c2be6fca048329b5c7ecfb6a9d3f3b)